### PR TITLE
Bump flint to version 3

### DIFF
--- a/bin/build_dependencies_unix.sh
+++ b/bin/build_dependencies_unix.sh
@@ -166,7 +166,9 @@ if [ $USE_GMP = "gmp" ]; then
       fi
 
       # Show the output of configfsf.guess
+      chmod +x configfsf.guess
       ./configfsf.guess
+
       ./configure --prefix=$PREFIX\
         --enable-fat\
         --enable-shared=yes\
@@ -174,6 +176,7 @@ if [ $USE_GMP = "gmp" ]; then
         --host=$HOST_ARG
       make -j3
       make install
+
     cd ..
 
   fi

--- a/bin/build_dependencies_unix.sh
+++ b/bin/build_dependencies_unix.sh
@@ -16,26 +16,35 @@ set -o errexit
 #                                                                           #
 # ------------------------------------------------------------------------- #
 
+SKIP_GMP=no
+SKIP_MPFR=no
+
 USE_GMP=gmp
 PATCH_GMP_ARM64=no
+BUILD_ARB=no
 
 while [[ $# -gt 0 ]]
 do
   key="$1"
   case $key in
     -h|--help)
-      echo "bin/download_dependencies.sh [--gmp gmp|mpir] [--host HOST]"
+      echo "bin/download_dependencies.sh [options]"
+      echo
+      echo "Build local installs of python-flint's dependencies."
+      echo
+      echo "Supported options:"
+      echo "  --help            - show this help message"
+      echo "  --host <HOST>     - set the host (target) for GMP build"
+      echo "  --skip-gmp        - skip building GMP"
+      echo "  --skip-mpfr       - skip building MPFR"
+      echo
+      echo "Legacy options:"
+      echo "  --gmp gmp         - build based on GMP (default)"
+      echo "  --gmp mpir        - build based on MPIR (no longer works)"
+      echo "  --patch-gmp-arm64 - apply patch to GMP 6.2.1 for OSX arm64"
+      echo "  --arb             - build Arb (only needed for flint < 3.0.0)"
+      echo
       exit
-    ;;
-    --gmp)
-      # e.g. --gmp gmp or --gmp mpir
-      USE_GMP="$2"
-      if [[ "$USE_GMP" != "gmp" && "$USE_GMP" != "mpir" ]]; then
-        echo "--gmp option should be gmp or mpir"
-        exit 1
-      fi
-      shift
-      shift
     ;;
     --host)
       # e.g. --host x86_64-unknown-linux-gnu
@@ -44,7 +53,38 @@ do
       shift
       shift
     ;;
+    --gmp)
+      # e.g. --gmp gmp or --gmp mpir
+      # The mpir build no longer works because the download fails.
+      USE_GMP="$2"
+      if [[ "$USE_GMP" != "gmp" && "$USE_GMP" != "mpir" ]]; then
+        echo "--gmp option should be gmp or mpir"
+        exit 1
+      fi
+      shift
+      shift
+    ;;
+    --arb)
+      # With flint >= 3.0.0 Arb is included so we do not need to build it
+      # separately. Pass --arb if building for older versions of flint.
+      BUILD_ARB=yes
+      shift
+    ;;
+    --skip-gmp)
+      # If you already have a local install of GMP you can pass --skip-gmp
+      # to skip building it.
+      SKIP_GMP=yes
+      shift
+    ;;
+    --skip-mpfr)
+      # If you already have a local install of MPFR you can pass --skip-mpfr
+      # to skip building it.
+      SKIP_MPFR=yes
+      shift
+    ;;
     --patch-gmp-arm64)
+      # Needed only for GMP 6.2.1 on OSX arm64 (Apple M1) hardware
+      # As of GMP 6.3.0 this patch is no longer needed
       PATCH_GMP_ARM64=yes
       shift
     ;;
@@ -86,42 +126,57 @@ if [ $USE_GMP = "gmp" ]; then
   #                                                                         #
   # ----------------------------------------------------------------------- #
 
-  if [ $USE_GMP_GITHUB_MIRROR = "yes" ]; then
-    # Needed in GitHub Actions because it is blocked from gmplib.org
-    git clone https://github.com/oscarbenjamin/gmp_mirror.git
-    cp gmp_mirror/gmp-$GMPVER.tar.xz .
+  if [ $SKIP_GMP = "yes" ]; then
+    echo
+    echo --------------------------------------------
+    echo "           skipping GMP"
+    echo --------------------------------------------
+    echo
   else
-    curl -O https://gmplib.org/download/gmp/gmp-$GMPVER.tar.xz
-  fi
+    echo
+    echo --------------------------------------------
+    echo "           building GMP"
+    echo --------------------------------------------
+    echo
 
-  tar xf gmp-$GMPVER.tar.xz
-  cd gmp-$GMPVER
-
-    #
-    # See https://github.com/aleaxit/gmpy/issues/350
-    #
-    # We need to patch GMP for OSX arm64 (Apple M1) hardware for GMP 6.2.1.
-    # Now with GMP 6.3.0 this should not be needed any more.
-    #
-    if [ $PATCH_GMP_ARM64 = "yes" ]; then
-      echo
-      echo --------------------------------------------
-      echo "           patching GMP"
-      echo --------------------------------------------
-      patch -N -Z -p0 < ../../../bin/patch-arm64.diff
+    if [ $USE_GMP_GITHUB_MIRROR = "yes" ]; then
+      # Needed in GitHub Actions because it is blocked from gmplib.org
+      git clone https://github.com/oscarbenjamin/gmp_mirror.git
+      cp gmp_mirror/gmp-$GMPVER.tar.xz .
+    else
+      curl -O https://gmplib.org/download/gmp/gmp-$GMPVER.tar.xz
     fi
 
-    # Show the output of configfsf.guess
-    chmod +x configfsf.guess
-    ./configfsf.guess
-    ./configure --prefix=$PREFIX\
-      --enable-fat\
-      --enable-shared=yes\
-      --enable-static=no\
-      --host=$HOST_ARG
-    make -j3
-    make install
-  cd ..
+    tar xf gmp-$GMPVER.tar.xz
+    cd gmp-$GMPVER
+
+      #
+      # See https://github.com/aleaxit/gmpy/issues/350
+      #
+      # We need to patch GMP for OSX arm64 (Apple M1) hardware. This patch is
+      # from the GMP repo but was applied after the release of GMP 6.2.1.
+      # This patch is no longer needed for GMP 6.3.0.
+      #
+      if [ $PATCH_GMP_ARM64 = "yes" ]; then
+        echo
+        echo --------------------------------------------
+        echo "           patching GMP"
+        echo --------------------------------------------
+        patch -N -Z -p0 < ../../../bin/patch-arm64.diff
+      fi
+
+      # Show the output of configfsf.guess
+      ./configfsf.guess
+      ./configure --prefix=$PREFIX\
+        --enable-fat\
+        --enable-shared=yes\
+        --enable-static=no\
+        --host=$HOST_ARG
+      make -j3
+      make install
+    cd ..
+
+  fi
 
   FLINTARB_WITHGMP="--with-gmp=$PREFIX"
 
@@ -182,16 +237,30 @@ fi
 #                                                                           #
 # ------------------------------------------------------------------------- #
 
-curl -O https://ftp.gnu.org/gnu/mpfr/mpfr-$MPFRVER.tar.gz
-tar xf mpfr-$MPFRVER.tar.gz
-cd mpfr-$MPFRVER
-  ./configure --prefix=$PREFIX\
-    --with-gmp=$PREFIX\
-    --enable-shared=yes\
-    --enable-static=no
-  make -j3
-  make install
-cd ..
+if [ $SKIP_MPFR = "yes" ]; then
+  echo
+  echo --------------------------------------------
+  echo "           skipping MPFR"
+  echo --------------------------------------------
+  echo
+else
+  echo
+  echo --------------------------------------------
+  echo "           building MPFR"
+  echo --------------------------------------------
+  echo
+
+  curl -O https://ftp.gnu.org/gnu/mpfr/mpfr-$MPFRVER.tar.gz
+  tar xf mpfr-$MPFRVER.tar.gz
+  cd mpfr-$MPFRVER
+    ./configure --prefix=$PREFIX\
+      --with-gmp=$PREFIX\
+      --enable-shared=yes\
+      --enable-static=no
+    make -j3
+    make install
+  cd ..
+fi
 
 # ------------------------------------------------------------------------- #
 #                                                                           #
@@ -199,9 +268,16 @@ cd ..
 #                                                                           #
 # ------------------------------------------------------------------------- #
 
+echo
+echo --------------------------------------------
+echo "           building Flint"
+echo --------------------------------------------
+echo
+
 curl -O -L https://www.flintlib.org/flint-$FLINTVER.tar.gz
 tar xf flint-$FLINTVER.tar.gz
 cd flint-$FLINTVER
+  ./bootstrap.sh
   ./configure --prefix=$PREFIX\
     $FLINTARB_WITHGMP\
     --with-mpfr=$PREFIX\
@@ -216,25 +292,34 @@ cd ..
 #                                                                           #
 # ------------------------------------------------------------------------- #
 
-curl -O -L https://github.com/fredrik-johansson/arb/archive/refs/tags/$ARBVER.tar.gz
-mv $ARBVER.tar.gz arb-$ARBVER.tar.gz
-tar xf arb-$ARBVER.tar.gz
-cd arb-$ARBVER
-  ./configure --prefix=$PREFIX\
-    --with-flint=$PREFIX\
-    $FLINTARB_WITHGMP\
-    --with-mpfr=$PREFIX\
-    --disable-static
-  make -j3
-  make install
-  #
-  # Set PATH so that DLLs are picked up on Windows.
-  #
-  PATH=$PATH:$PREFIX/lib:$PREFIX/bin \
-  ARB_TEST_MULTIPLIER=0.1            \
-  # Skip Arb tests now because they are slow.
-  # make check
-cd ..
+if [ $BUILD_ARB = "yes" ]; then
+
+  echo
+  echo --------------------------------------------
+  echo "           building Arb"
+  echo --------------------------------------------
+  echo
+
+  curl -O -L https://github.com/fredrik-johansson/arb/archive/refs/tags/$ARBVER.tar.gz
+  mv $ARBVER.tar.gz arb-$ARBVER.tar.gz
+  tar xf arb-$ARBVER.tar.gz
+  cd arb-$ARBVER
+    ./configure --prefix=$PREFIX\
+      --with-flint=$PREFIX\
+      $FLINTARB_WITHGMP\
+      --with-mpfr=$PREFIX\
+      --disable-static
+    make -j3
+    make install
+    #
+    # Set PATH so that DLLs are picked up on Windows.
+    #
+    PATH=$PATH:$PREFIX/lib:$PREFIX/bin \
+    ARB_TEST_MULTIPLIER=0.1            \
+    # Skip Arb tests now because they are slow.
+    # make check
+  cd ..
+fi
 
 # ------------------------------------------------------------------------- #
 #                                                                           #
@@ -249,14 +334,28 @@ echo Build dependencies for python-flint compiled as shared libraries in:
 echo $PREFIX
 echo
 echo Versions:
-if [[ $USE_GMP = "gmp" ]]; then
-  echo GMP: $GMPVER
+
+if [ $SKIP_GMP = "yes" ]; then
+  echo GMP: skipped
 else
-  echo MPIR: $MPIRVER
+  if [[ $USE_GMP = "gmp" ]]; then
+    echo GMP: $GMPVER
+  else
+    echo MPIR: $MPIRVER
+  fi
 fi
-echo MPFR: $MPFRVER
+
+if [ $SKIP_MPFR = "yes" ]; then
+  echo MPFR: skipped
+else
+  echo MPFR: $MPFRVER
+fi
+
 echo Flint: $FLINTVER
-echo Arb: $ARBVER
+
+if [ $BUILD_ARB = "yes" ]; then
+  echo Arb: $ARBVER
+fi
 echo
 echo -----------------------------------------------------------------------
 echo

--- a/bin/build_variables.sh
+++ b/bin/build_variables.sh
@@ -13,9 +13,12 @@
 PREFIX=$(pwd)/.local
 mkdir -p $PREFIX
 
+ARBVER=2.23.0 # Not needed with flint >= 3.0.0 (Arb is included in flint)
+
+YASMVER=1.3.0 # Only needed for MPIR
+MPIRVER=3.0.0 # MPIR build no longer works (not clear where to download from)
+
+# These are the actual dependencies used (at least by default):
 GMPVER=6.3.0
-YASMVER=1.3.0
-MPIRVER=3.0.0
 MPFRVER=4.1.0
-FLINTVER=2.9.0
-ARBVER=2.23.0
+FLINTVER=3.0.0-alpha1

--- a/bin/cibw_before_all_macosx_arm64.sh
+++ b/bin/cibw_before_all_macosx_arm64.sh
@@ -3,7 +3,7 @@
 export CPPFLAGS=" --target=arm64-apple-macos11"
 export LDFLAGS=" -arch arm64"
 
-brew install automake
+brew install automake libtool
 
 bin/build_dependencies_unix.sh\
   --gmp gmp\

--- a/bin/cibw_before_all_macosx_arm64.sh
+++ b/bin/cibw_before_all_macosx_arm64.sh
@@ -3,6 +3,8 @@
 export CPPFLAGS=" --target=arm64-apple-macos11"
 export LDFLAGS=" -arch arm64"
 
+brew install automake
+
 bin/build_dependencies_unix.sh\
   --gmp gmp\
   --host aarch64-apple-darwin\

--- a/bin/cibw_before_all_macosx_x86_64.sh
+++ b/bin/cibw_before_all_macosx_x86_64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-brew install automake
+brew install automake libtool
 
 bin/build_dependencies_unix.sh\
   --gmp gmp\

--- a/bin/cibw_before_all_macosx_x86_64.sh
+++ b/bin/cibw_before_all_macosx_x86_64.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+brew install automake
+
 bin/build_dependencies_unix.sh\
   --gmp gmp\
   --host x86_64-apple-darwin\

--- a/bin/cibw_before_all_windows.sh
+++ b/bin/cibw_before_all_windows.sh
@@ -21,6 +21,7 @@ pacman -S --noconfirm \
     make\
     base-devel\
     autoconf-wrapper\
+    automake-wrapper\
     #
 
 # This takes ~30mins

--- a/bin/cibw_before_all_windows.sh
+++ b/bin/cibw_before_all_windows.sh
@@ -20,6 +20,7 @@ pacman -S --noconfirm \
     m4\
     make\
     base-devel\
+    autoconf-wrapper\
     #
 
 # This takes ~30mins

--- a/bin/cibw_before_all_windows.sh
+++ b/bin/cibw_before_all_windows.sh
@@ -22,6 +22,7 @@ pacman -S --noconfirm \
     base-devel\
     autoconf-wrapper\
     automake-wrapper\
+    libtool\
     #
 
 # This takes ~30mins

--- a/bin/cibw_before_all_windows.sh
+++ b/bin/cibw_before_all_windows.sh
@@ -13,8 +13,14 @@ echo '[build]' > setup.cfg
 echo 'compiler = mingw32' >> setup.cfg
 cat setup.cfg
 
-# Install the mingw-w64 toolchain
-pacman -S --noconfirm mingw-w64-x86_64-gcc m4 make mingw-w64-x86_64-tools-git
+# Install the mingw-w64 toolchain and build tools
+pacman -S --noconfirm \
+    mingw-w64-x86_64-gcc\
+    mingw-w64-x86_64-tools-git\
+    m4\
+    make\
+    base-devel\
+    #
 
 # This takes ~30mins
 bin/build_dependencies_unix.sh --use-gmp-github-mirror

--- a/bin/cibw_repair_wheel_command_windows.sh
+++ b/bin/cibw_repair_wheel_command_windows.sh
@@ -29,8 +29,11 @@ wheeldir=$(dirname $WHEELNAME)
 echo $wheeldir
 
 # delvewheel requires DLLs created by mingw64 to be stripped. This strips the
-# DLLs for GMP etc that will have been build previously.
-strip .local/bin/*.dll .local/lib/*.dll
+# DLLs for GMP etc that will have been built in the CIBW_BEFORE_ALL step.
+#
+# Previously the Arb DLLs would have been placed in .local/lib, but as of
+# flint 3.0.0 all DLLs aRe in .local/bin.
+strip .local/bin/*.dll
 
 # Make sure to leave the wheel in the same directory
 wheeldir=$(dirname $WHEELNAME)
@@ -47,4 +50,4 @@ popd
 # .pyd files that are needed for the wheel.
 delvewheel repair $WHEELNAME 	\
 	-w $WHEELHOUSE		\
-	--add-path .local/bin:.local/lib/
+	--add-path .local/bin

--- a/bin/pip_install_ubuntu.sh
+++ b/bin/pip_install_ubuntu.sh
@@ -14,39 +14,16 @@ set -o errexit
 
 # Install runtime and build dependencies
 
-# The commented commands below would attempt to build python-flint against a
-# system installation of Flint and Arb in Ubuntu.
-#
-# Ubuntu 23.04 has Flint 2.9.0 and Arb 2.23.0, so this script might work there
-# (for python-flint 0.4.x). That is untested though (23.04 not available in CI).
-#
-# With Ubuntu 22.04, this will build but then crashes when running the tests.
-# most likely this is because the versions of flint and flint-arb are too old.
-# At the time of writing in Ubuntu 22.04 there is Flint 2.8.4 and Arb 2.22. The
-# main CI tests and wheels for python-flint 0.4.x are built with Flint 2.9.0
-# and Arb 2.23.0.
-#
-# Link against libflint-arb instead of libarb on Ubuntu
-# export PYTHON_FLINT_LIBFLINT_ARB=1
-# sudo apt-get update
-# sudo apt-get install libflint-dev libflint-arb-dev
-
-
-# Build Flint and Arb manually
-#
 # First install their dependencies and build dependencies
 sudo apt-get update
 sudo apt-get install libgmp-dev libmpfr-dev xz-utils
 
-# Only these *EXACT* versions will work.
-FLINTVER=2.9.0
-ARBVER=2.23.0
+# Only Flint 3 or newer will work.
+FLINTVER=3.0.0-alpha1
 
 # This will default to installing in /usr/local. If you want to install in a
 # non-standard location then configure flint with
 #    ./configure --disable-static --prefix=$PREFIX
-# and arb with
-#    ./configure --disable-static --prefix=$PREFIX --with-flint=$PREFIX
 # If $PREFIX is no in default search paths, then at build time set
 #    export C_INCLUDE_PATH=$PREFIX/include
 # and at runtime set
@@ -55,15 +32,7 @@ ARBVER=2.23.0
 curl -O -L https://www.flintlib.org/flint-$FLINTVER.tar.gz
 tar xf flint-$FLINTVER.tar.gz
 cd flint-$FLINTVER
-  ./configure --disable-static
-  make -j
-  sudo make install
-cd ..
-
-curl -O -L https://github.com/fredrik-johansson/arb/archive/refs/tags/$ARBVER.tar.gz
-mv $ARBVER.tar.gz arb-$ARBVER.tar.gz
-tar xf arb-$ARBVER.tar.gz
-cd arb-$ARBVER
+  ./bootstrap.sh
   ./configure --disable-static
   make -j
   sudo make install

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.platform == 'win32':
     # This is used in CI to build wheels with mingw64
     #
     if os.getenv('PYTHON_FLINT_MINGW64'):
-        libraries = ["arb", "flint", "mpfr", "gmp"]
+        libraries = ["flint", "mpfr", "gmp"]
         includedir = os.path.join(os.path.dirname(__file__), '.local', 'include')
         librarydir1 = os.path.join(os.path.dirname(__file__), '.local', 'bin')
         librarydir2 = os.path.join(os.path.dirname(__file__), '.local', 'lib')
@@ -29,18 +29,12 @@ if sys.platform == 'win32':
     elif os.getenv('PYTHON_FLINT_MINGW64_TMP'):
         # This would be used to build under Windows against these libraries if
         # they have been installed somewhere other than .local
-        libraries = ["arb", "flint", "mpfr", "gmp"]
+        libraries = ["flint", "mpfr", "gmp"]
     else:
         # For the MSVC toolchain link with mpir instead of gmp
-        libraries = ["arb", "flint", "mpir", "mpfr", "pthreads"]
+        libraries = ["flint", "mpir", "mpfr", "pthreads"]
 else:
-    # On Ubuntu libarb.so is called libflint-arb.so
-    if os.getenv('PYTHON_FLINT_LIBFLINT_ARB'):
-        arb = 'flint-arb'
-    else:
-        arb = 'arb'
-
-    libraries = [arb, "flint"]
+    libraries = ["flint"]
     (opt,) = get_config_vars('OPT')
     os.environ['OPT'] = " ".join(flag for flag in opt.split() if flag != '-Wstrict-prototypes')
 

--- a/src/flint/flintlib/acb.pxd
+++ b/src/flint/flintlib/acb.pxd
@@ -5,7 +5,7 @@ from flint.flintlib.fmpz cimport fmpz_t
 from flint.flintlib.arf cimport arf_t
 from flint.flintlib.mag cimport mag_t
 
-cdef extern from "acb.h":
+cdef extern from "flint/acb.h":
     ctypedef struct acb_struct:
         arb_struct real
         arb_struct imag

--- a/src/flint/flintlib/acb_calc.pxd
+++ b/src/flint/flintlib/acb_calc.pxd
@@ -1,7 +1,7 @@
 from flint.flintlib.acb cimport acb_t, acb_ptr
 from flint.flintlib.mag cimport mag_t
 
-cdef extern from "acb_calc.h":
+cdef extern from "flint/acb_calc.h":
     ctypedef int (*acb_calc_func_t)(acb_ptr out, const acb_t inp, void * param, long order, long prec)
 
     ctypedef struct acb_calc_integrate_opt_struct:

--- a/src/flint/flintlib/acb_dft.pxd
+++ b/src/flint/flintlib/acb_dft.pxd
@@ -1,5 +1,5 @@
 from flint.flintlib.acb cimport acb_ptr, acb_srcptr
 
-cdef extern from "acb_dft.h":
+cdef extern from "flint/acb_dft.h":
     void acb_dft(acb_ptr w, acb_srcptr v, long n, long prec)
     void acb_dft_inverse(acb_ptr w, acb_srcptr v, long n, long prec)

--- a/src/flint/flintlib/acb_dirichlet.pxd
+++ b/src/flint/flintlib/acb_dirichlet.pxd
@@ -6,7 +6,7 @@ from flint.flintlib.fmpz cimport fmpz_t
 from flint.flintlib.arb cimport arb_t
 
 
-cdef extern from "acb_dirichlet.h":
+cdef extern from "flint/acb_dirichlet.h":
     void acb_dirichlet_eta(acb_t res, const acb_t s, long prec)
     void acb_dirichlet_chi(acb_t res, const dirichlet_group_t G, const dirichlet_char_t chi, ulong n, long prec)
 

--- a/src/flint/flintlib/acb_elliptic.pxd
+++ b/src/flint/flintlib/acb_elliptic.pxd
@@ -1,6 +1,6 @@
 from flint.flintlib.acb cimport acb_t
 
-cdef extern from "acb_elliptic.h":
+cdef extern from "flint/acb_elliptic.h":
     void acb_elliptic_rf(acb_t res, const acb_t x, const acb_t y, const acb_t z, int flags, long prec)
     void acb_elliptic_rj(acb_t res, const acb_t x, const acb_t y, const acb_t z, const acb_t p, int flags, long prec)
     void acb_elliptic_rg(acb_t res, const acb_t x, const acb_t y, const acb_t z, int flags, long prec)

--- a/src/flint/flintlib/acb_hypgeom.pxd
+++ b/src/flint/flintlib/acb_hypgeom.pxd
@@ -2,7 +2,7 @@ from flint.flintlib.acb cimport acb_t, acb_srcptr, acb_ptr
 from flint.flintlib.acb_poly cimport acb_poly_t, acb_poly_struct
 from flint.flintlib.mag cimport mag_t
 
-cdef extern from "acb_hypgeom.h":
+cdef extern from "flint/acb_hypgeom.h":
     void acb_hypgeom_bessel_j(acb_t res, const acb_t nu, const acb_t z, long prec)
     void acb_hypgeom_bessel_k(acb_t res, const acb_t nu, const acb_t z, long prec)
     void acb_hypgeom_bessel_i(acb_t res, const acb_t nu, const acb_t z, long prec)

--- a/src/flint/flintlib/acb_mat.pxd
+++ b/src/flint/flintlib/acb_mat.pxd
@@ -7,7 +7,7 @@ from flint.flintlib.acb_poly cimport acb_poly_t
 from flint.flintlib.arb cimport arb_t
 from flint.flintlib.acb cimport  acb_ptr, acb_struct, acb_t, acb_srcptr
 
-cdef extern from "acb_mat.h":
+cdef extern from "flint/acb_mat.h":
     ctypedef struct acb_mat_struct:
         acb_ptr entries
         long r

--- a/src/flint/flintlib/acb_modular.pxd
+++ b/src/flint/flintlib/acb_modular.pxd
@@ -2,7 +2,7 @@ from flint.flintlib.acb cimport acb_t, acb_ptr
 from flint.flintlib.acb_poly cimport acb_poly_t
 from flint.flintlib.fmpz_poly cimport fmpz_poly_t
 
-cdef extern from "acb_modular.h":
+cdef extern from "flint/acb_modular.h":
     void acb_modular_theta(acb_t theta1, acb_t theta2, acb_t theta3, acb_t theta4, const acb_t z, const acb_t tau, long prec)
     void acb_modular_theta_jet(acb_ptr theta1, acb_ptr theta2, acb_ptr theta3, acb_ptr theta4, const acb_t z, const acb_t tau, long len, long prec)
     void acb_modular_theta_series(acb_poly_t theta1, acb_poly_t theta2, acb_poly_t theta3, acb_poly_t theta4, const acb_poly_t z, const acb_t tau, long len, long prec)

--- a/src/flint/flintlib/acb_poly.pxd
+++ b/src/flint/flintlib/acb_poly.pxd
@@ -6,7 +6,7 @@ from flint.flintlib.fmpz_poly cimport fmpz_poly_t
 from flint.flintlib.mag cimport mag_t
 from flint.flintlib.fmpz cimport fmpz_t
 
-cdef extern from "acb_poly.h":
+cdef extern from "flint/acb_poly.h":
     ctypedef struct acb_poly_struct:
         acb_ptr coeffs
         long length

--- a/src/flint/flintlib/arb.pxd
+++ b/src/flint/flintlib/arb.pxd
@@ -4,7 +4,7 @@ from flint.flintlib.fmpq cimport fmpq_t
 from flint.flintlib.arf cimport arf_struct, arf_ptr, arf_t
 from flint.flintlib.mag cimport mag_struct, mag_ptr, mag_t
 
-cdef extern from "arb.h":
+cdef extern from "flint/arb.h":
     ctypedef struct arb_struct:
         arf_struct mid
         mag_struct rad

--- a/src/flint/flintlib/arb_fmpz_poly.pxd
+++ b/src/flint/flintlib/arb_fmpz_poly.pxd
@@ -3,7 +3,7 @@ from flint.flintlib.acb cimport acb_t, acb_ptr
 from flint.flintlib.fmpz_poly cimport fmpz_poly_t
 from flint._flint cimport ulong
 
-cdef extern from "arb_fmpz_poly.h":
+cdef extern from "flint/arb_fmpz_poly.h":
     void arb_fmpz_poly_evaluate_arb(arb_t res, const fmpz_poly_t poly, const arb_t x, long prec)
     void arb_fmpz_poly_evaluate_acb(acb_t res, const fmpz_poly_t poly, const acb_t x, long prec)
     void arb_fmpz_poly_complex_roots(acb_ptr roots, const fmpz_poly_t poly, int flags, long prec)

--- a/src/flint/flintlib/arb_hypgeom.pxd
+++ b/src/flint/flintlib/arb_hypgeom.pxd
@@ -3,7 +3,7 @@ from flint.flintlib.arb_poly cimport arb_poly_t
 from flint.flintlib.fmpz cimport fmpz_t
 from flint._flint cimport ulong
 
-cdef extern from "arb_hypgeom.h":
+cdef extern from "flint/arb_hypgeom.h":
     void arb_hypgeom_pfq(arb_t res, arb_srcptr a, long p, arb_srcptr b, long q, const arb_t z, int regularized, long prec)
     void arb_hypgeom_0f1(arb_t res, const arb_t a, const arb_t z, int regularized, long prec)
     void arb_hypgeom_m(arb_t res, const arb_t a, const arb_t b, const arb_t z, int regularized, long prec)

--- a/src/flint/flintlib/arb_mat.pxd
+++ b/src/flint/flintlib/arb_mat.pxd
@@ -7,7 +7,7 @@ from flint.flintlib.fmpz cimport fmpz_t
 from flint.flintlib.arb cimport arb_t
 from flint.flintlib.arb_poly cimport arb_poly_t
 
-cdef extern from "arb_mat.h":
+cdef extern from "flint/arb_mat.h":
     ctypedef struct arb_mat_struct:
         arb_ptr entries
         long r

--- a/src/flint/flintlib/arb_poly.pxd
+++ b/src/flint/flintlib/arb_poly.pxd
@@ -4,7 +4,7 @@ from flint.flintlib.fmpz_poly cimport fmpz_poly_t
 from flint.flintlib.fmpq_poly cimport fmpq_poly_t
 from flint.flintlib.acb cimport acb_t
 
-cdef extern from "arb_poly.h":
+cdef extern from "flint/arb_poly.h":
     ctypedef struct arb_poly_struct:
         arb_ptr coeffs
         long length

--- a/src/flint/flintlib/arf.pxd
+++ b/src/flint/flintlib/arf.pxd
@@ -3,7 +3,7 @@ from flint._flint cimport mp_limb_t, ulong, flint_rand_t
 from flint.flintlib.fmpq cimport fmpq_t
 from flint.flintlib.mag cimport mag_t
 
-cdef extern from "arf.h":
+cdef extern from "flint/arf.h":
     ctypedef struct arf_struct:
         fmpz_struct exp
         long size

--- a/src/flint/flintlib/bernoulli.pxd
+++ b/src/flint/flintlib/bernoulli.pxd
@@ -1,6 +1,6 @@
 from flint._flint cimport ulong
 from flint.flintlib.fmpq cimport fmpq_t
 
-cdef extern from "bernoulli.h":
+cdef extern from "flint/bernoulli.h":
     void bernoulli_fmpq_ui(fmpq_t, ulong)
     void bernoulli_cache_compute(long n)

--- a/src/flint/flintlib/dirichlet.pxd
+++ b/src/flint/flintlib/dirichlet.pxd
@@ -1,7 +1,7 @@
 from flint._flint cimport ulong
 from flint.flintlib.nmod_vec cimport nmod_t
 
-cdef extern from "dirichlet.h":
+cdef extern from "flint/dirichlet.h":
     ctypedef struct dirichlet_group_struct:
         ulong q
         ulong q_even

--- a/src/flint/flintlib/dirichlet.pxd
+++ b/src/flint/flintlib/dirichlet.pxd
@@ -1,5 +1,5 @@
 from flint._flint cimport ulong
-from flint.flintlib.nmod_vec cimport nmod_t
+from flint.flintlib.nmod cimport nmod_t
 
 cdef extern from "flint/dirichlet.h":
     ctypedef struct dirichlet_group_struct:

--- a/src/flint/flintlib/mag.pxd
+++ b/src/flint/flintlib/mag.pxd
@@ -1,7 +1,7 @@
 from flint._flint cimport ulong, mp_limb_t
 from flint.flintlib.fmpz cimport fmpz_struct
 
-cdef extern from "mag.h":
+cdef extern from "flint/mag.h":
     ctypedef struct mag_struct:
         fmpz_struct exp
         mp_limb_t man

--- a/src/flint/flintlib/nmod.pxd
+++ b/src/flint/flintlib/nmod.pxd
@@ -1,6 +1,6 @@
 from flint._flint cimport mp_limb_t, mp_bitcnt_t
 
-cdef extern from "flint/nmod_vec.h":
+cdef extern from "flint/nmod.h":
     ctypedef struct nmod_t:
        mp_limb_t n
        mp_limb_t ninv

--- a/src/flint/flintlib/nmod_mat.pxd
+++ b/src/flint/flintlib/nmod_mat.pxd
@@ -1,6 +1,6 @@
 from flint._flint cimport mp_limb_t, flint_rand_t, mp_ptr
 from flint._flint cimport mp_srcptr
-from flint.flintlib.nmod_vec cimport nmod_t
+from flint.flintlib.nmod cimport nmod_t
 from flint.flintlib.nmod_poly cimport nmod_poly_t
 
 cdef extern from "flint/nmod_mat.h":

--- a/src/flint/flintlib/nmod_poly.pxd
+++ b/src/flint/flintlib/nmod_poly.pxd
@@ -10,13 +10,6 @@ cdef extern from "flint/nmod_poly.h":
         nmod_t mod
     ctypedef nmod_poly_struct nmod_poly_t[1]
 
-    ctypedef struct nmod_poly_factor_struct:
-        nmod_poly_struct *p
-        long *exp
-        long num
-        long alloc
-    ctypedef nmod_poly_factor_struct nmod_poly_factor_t[1]
-
     void nmod_poly_init(nmod_poly_t poly, mp_limb_t n)
     void nmod_poly_init_preinv(nmod_poly_t poly, mp_limb_t n, mp_limb_t ninv)
     void nmod_poly_init2(nmod_poly_t poly, mp_limb_t n, long alloc)
@@ -76,10 +69,3 @@ cdef extern from "flint/nmod_poly.h":
     void nmod_poly_tanh_series(nmod_poly_t g, nmod_poly_t h, long n)
     void nmod_poly_log_series(nmod_poly_t res, nmod_poly_t f, long n)
     void nmod_poly_exp_series(nmod_poly_t f, nmod_poly_t h, long n)
-
-    int nmod_poly_is_irreducible(nmod_poly_t f)
-    mp_limb_t nmod_poly_factor_with_berlekamp(nmod_poly_factor_t result, nmod_poly_t poly)
-    mp_limb_t nmod_poly_factor_with_cantor_zassenhaus(nmod_poly_factor_t result, nmod_poly_t poly)
-    mp_limb_t nmod_poly_factor(nmod_poly_factor_t result, nmod_poly_t input)
-    void nmod_poly_factor_init(nmod_poly_factor_t fac)
-    void nmod_poly_factor_clear(nmod_poly_factor_t fac)

--- a/src/flint/flintlib/nmod_poly.pxd
+++ b/src/flint/flintlib/nmod_poly.pxd
@@ -1,6 +1,6 @@
 from flint._flint cimport mp_ptr, mp_limb_t, mp_bitcnt_t
 from flint._flint cimport flint_rand_t, ulong
-from flint.flintlib.nmod_vec cimport nmod_t
+from flint.flintlib.nmod cimport nmod_t
 
 cdef extern from "flint/nmod_poly.h":
     ctypedef struct nmod_poly_struct:

--- a/src/flint/flintlib/nmod_poly_factor.pxd
+++ b/src/flint/flintlib/nmod_poly_factor.pxd
@@ -1,0 +1,17 @@
+from flint._flint cimport mp_limb_t
+from flint.flintlib.nmod_poly cimport nmod_poly_struct, nmod_poly_t
+
+cdef extern from "flint/nmod_poly_factor.h":
+    ctypedef struct nmod_poly_factor_struct:
+        nmod_poly_struct *p
+        long *exp
+        long num
+        long alloc
+    ctypedef nmod_poly_factor_struct nmod_poly_factor_t[1]
+
+    int nmod_poly_is_irreducible(nmod_poly_t f)
+    mp_limb_t nmod_poly_factor_with_berlekamp(nmod_poly_factor_t result, nmod_poly_t poly)
+    mp_limb_t nmod_poly_factor_with_cantor_zassenhaus(nmod_poly_factor_t result, nmod_poly_t poly)
+    mp_limb_t nmod_poly_factor(nmod_poly_factor_t result, nmod_poly_t input)
+    void nmod_poly_factor_init(nmod_poly_factor_t fac)
+    void nmod_poly_factor_clear(nmod_poly_factor_t fac)

--- a/src/flint/flintlib/partitions.pxd
+++ b/src/flint/flintlib/partitions.pxd
@@ -1,4 +1,4 @@
 from flint.flintlib.fmpz cimport fmpz_t
 
-cdef extern from "partitions.h":
+cdef extern from "flint/partitions.h":
     void partitions_fmpz_fmpz(fmpz_t, const fmpz_t, int)

--- a/src/flint/types/nmod.pxd
+++ b/src/flint/types/nmod.pxd
@@ -1,6 +1,6 @@
 from flint.flint_base.flint_base cimport flint_scalar
 from flint._flint cimport mp_limb_t
-from flint.flintlib.nmod_vec cimport nmod_t
+from flint.flintlib.nmod cimport nmod_t
 
 cdef int any_as_nmod(mp_limb_t * val, obj, nmod_t mod) except -1
 

--- a/src/flint/types/nmod.pyx
+++ b/src/flint/types/nmod.pyx
@@ -6,7 +6,7 @@ from flint.types.fmpz cimport fmpz
 from flint.types.fmpq cimport fmpq
 
 from flint.flintlib.fmpz cimport fmpz_t
-from flint.flintlib.nmod_vec cimport *
+from flint.flintlib.nmod cimport *
 from flint.flintlib.fmpz cimport fmpz_fdiv_ui, fmpz_init, fmpz_clear
 from flint.flintlib.fmpz cimport fmpz_set_ui, fmpz_get_ui
 from flint.flintlib.fmpq cimport fmpq_mod_fmpz

--- a/src/flint/types/nmod_poly.pyx
+++ b/src/flint/types/nmod_poly.pyx
@@ -8,6 +8,7 @@ from flint.types.nmod cimport nmod
 
 from flint.flintlib.nmod_vec cimport *
 from flint.flintlib.nmod_poly cimport *
+from flint.flintlib.nmod_poly_factor cimport *
 from flint.flintlib.fmpz_poly cimport fmpz_poly_get_nmod_poly
 
 cdef any_as_nmod_poly(obj, nmod_t mod):

--- a/src/flint/types/nmod_poly.pyx
+++ b/src/flint/types/nmod_poly.pyx
@@ -6,7 +6,7 @@ from flint.types.fmpz_poly cimport fmpz_poly
 from flint.types.nmod cimport any_as_nmod
 from flint.types.nmod cimport nmod
 
-from flint.flintlib.nmod_vec cimport *
+from flint.flintlib.nmod cimport *
 from flint.flintlib.nmod_poly cimport *
 from flint.flintlib.nmod_poly_factor cimport *
 from flint.flintlib.fmpz_poly cimport fmpz_poly_get_nmod_poly


### PR DESCRIPTION
Following on from https://github.com/fredrik-johansson/python-flint/pull/35#issuecomment-1664259927

Bumps the flint version to 3.0.0-alpha1. Mostly all that is needed is removing `-larb` from setup.py and renaming the Arb headers. Also the build scripts need to not build Arb separately any more.

We can use this to see in CI that python_flint is ready for flint 3 but it should only be merged after flint 3 is released.

At first CI will fail because of Cython 3 (gh-35 needs to be merged first or the Cython version should be pinned again).