### PR TITLE
Finish the `flint_base` submodule, depreciate old roots and factor out more utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ To do
 * Improved printing and string input/output
 * IPython hooks (TeX pretty-printing etc.)
 
+CHANGELOG
+-------------
+
+0.5.0
+
+- gh-63: The `roots` method of `arb_poly`, and `nmod_poly` is no longer supported. Use `acb_roots(p).roots()` to get the old behaviour of returning the roots as `acb`. Note that the `roots` method of `fmpz_poly` and `fmpq_poly` currently returns the complex roots of the polynomial.
+
 License
 ------------
 

--- a/src/flint/acb.pyx
+++ b/src/flint/acb.pyx
@@ -1,3 +1,4 @@
+from flint.utils.typecheck cimport typecheck
 from flint.flint_base.flint_base cimport flint_scalar
 from flint.flint_base.flint_context cimport getprec
 

--- a/src/flint/acb_mat.pyx
+++ b/src/flint/acb_mat.pyx
@@ -1,5 +1,5 @@
+from flint.utils.typecheck cimport typecheck
 from flint.flint_base.flint_context cimport getprec
-
 from flint.flint_base.flint_base cimport flint_mat
 
 cdef acb_mat_coerce_operands(x, y):

--- a/src/flint/acb_poly.pyx
+++ b/src/flint/acb_poly.pyx
@@ -1,7 +1,6 @@
+from flint.utils.typecheck cimport typecheck
 from flint.flint_base.flint_context cimport getprec
-# TODO: waiting for fix on the roots method, currently 
-# globally defined.
-# from flint.flint_base.flint_base cimport flint_poly
+from flint.flint_base.flint_base cimport flint_poly
 
 cdef acb_poly_coerce_operands(x, y):
     if isinstance(y, (int, long, float, complex, fmpz, fmpq, arb, acb, fmpz_poly, fmpq_poly, arb_poly)):

--- a/src/flint/acb_series.pyx
+++ b/src/flint/acb_series.pyx
@@ -1,3 +1,4 @@
+from flint.utils.typecheck cimport typecheck
 from flint.flint_base.flint_context cimport getprec, getcap
 from flint.flint_base.flint_base cimport flint_series
 

--- a/src/flint/arb.pyx
+++ b/src/flint/arb.pyx
@@ -2,6 +2,7 @@ from cpython.version cimport PY_MAJOR_VERSION
 
 from flint.flint_base.flint_context cimport getprec
 from flint.flint_base.flint_base cimport flint_scalar
+from flint.utils.typecheck cimport typecheck
 from flint.utils.conversion cimport chars_from_str, str_from_chars
 
 cdef _str_trunc(s, trunc=0):

--- a/src/flint/arb_mat.pyx
+++ b/src/flint/arb_mat.pyx
@@ -1,3 +1,4 @@
+from flint.utils.typecheck cimport typecheck
 from flint.flint_base.flint_context cimport getprec
 from flint.flint_base.flint_base cimport flint_mat
 

--- a/src/flint/arb_poly.pyx
+++ b/src/flint/arb_poly.pyx
@@ -1,7 +1,6 @@
+from flint.utils.typecheck cimport typecheck
 from flint.flint_base.flint_context cimport getprec
-# TODO: waiting for fix on the roots method, currently 
-# globally defined.
-# from flint.flint_base.flint_base cimport flint_poly
+from flint.flint_base.flint_base cimport flint_poly
 
 cdef arb_poly_coerce_operands(x, y):
     if isinstance(y, (int, long, float, fmpz, fmpq, arb, fmpz_poly, fmpq_poly)):

--- a/src/flint/arb_series.pyx
+++ b/src/flint/arb_series.pyx
@@ -1,3 +1,4 @@
+from flint.utils.typecheck cimport typecheck
 from flint.flint_base.flint_context cimport getprec, getcap
 from flint.flint_base.flint_base cimport flint_series
 

--- a/src/flint/arf.pyx
+++ b/src/flint/arf.pyx
@@ -1,4 +1,5 @@
 from flint.flint_base.flint_context cimport getprec
+from flint.utils.typecheck cimport typecheck
 from flint.utils.conversion cimport prec_to_dps
 
 cdef class arf:

--- a/src/flint/flint_base/flint_base.pxd
+++ b/src/flint/flint_base/flint_base.pxd
@@ -4,10 +4,8 @@ cdef class flint_elem:
 cdef class flint_scalar(flint_elem):
     pass
 
-# TODO:
-# See .pyx file
-# cdef class flint_poly(flint_elem):
-#     pass
+cdef class flint_poly(flint_elem):
+    pass
 
 cdef class flint_mpoly(flint_elem):
     pass

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -72,7 +72,7 @@ cdef class flint_poly(flint_elem):
 
         acb_poly(input_poly).roots()
         """
-        raise NotImplementedError('This method has been deprecated. Please instead use acb_poly(input_poly).roots()')
+        raise NotImplementedError('This method is no longer supported. To recover the complex roots first convert to acb_poly')
         
 
 

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from flint.flint_base.flint_context cimport thectx
 
 cdef class flint_elem:
@@ -10,77 +12,77 @@ cdef class flint_elem:
     def __str__(self):
         return self.str()
 
+
 cdef class flint_scalar(flint_elem):
     pass
- 
-# TODO:
-# We cannot include this class until we can import
-# acb_poly, so for now we leave this class as a global
-# inside pyflint.pyx
-# 
-# cdef class flint_poly(flint_elem):
-#     """
-#     Base class for polynomials.
-#     """
 
-#     def __iter__(self):
-#         cdef long i, n
-#         n = self.length()
-#         for i in range(n):
-#             yield self[i]
 
-#     def coeffs(self):
-#         return list(self)
+cdef class flint_poly(flint_elem):
+    """
+    Base class for polynomials.
+    """
 
-#     def str(self, bint ascending=False):
-#         """
-#         Convert to a human-readable string (generic implementation for
-#         all polynomial types).
+    def __iter__(self):
+        cdef long i, n
+        n = self.length()
+        for i in range(n):
+            yield self[i]
 
-#         If *ascending* is *True*, the monomials are output from low degree to
-#         high, otherwise from high to low.
-#         """
-#         coeffs = [str(c) for c in self]
-#         if not coeffs:
-#             return "0"
-#         s = []
-#         coeffs = enumerate(coeffs)
-#         if not ascending:
-#             coeffs = reversed(list(coeffs))
-#         for i, c in coeffs:
-#             if c == "0":
-#                 continue
-#             else:
-#                 if c.startswith("-") or (" " in c):
-#                     c = "(" + c + ")"
-#                 if i == 0:
-#                     s.append("%s" % c)
-#                 elif i == 1:
-#                     if c == "1":
-#                         s.append("x")
-#                     else:
-#                         s.append("%s*x" % c)
-#                 else:
-#                     if c == "1":
-#                         s.append("x^%s" % i)
-#                     else:
-#                         s.append("%s*x^%s" % (c, i))
-#         return " + ".join(s)
+    def coeffs(self):
+        return list(self)
 
-#     def roots(self, **kwargs):
-#         """
-#         Isolates the complex roots of *self*. See :meth:`.acb_poly.roots`
-#         for details.
-#         """
-#         # TODO: 
-#         # To avoid circular imports, we import within the method
-#         from XXX.XXX.acb_poly import acb_poly
-#         return acb_poly(self).roots(**kwargs)
+    def str(self, bint ascending=False):
+        """
+        Convert to a human-readable string (generic implementation for
+        all polynomial types).
+
+        If *ascending* is *True*, the monomials are output from low degree to
+        high, otherwise from high to low.
+        """
+        coeffs = [str(c) for c in self]
+        if not coeffs:
+            return "0"
+        s = []
+        coeffs = enumerate(coeffs)
+        if not ascending:
+            coeffs = reversed(list(coeffs))
+        for i, c in coeffs:
+            if c == "0":
+                continue
+            else:
+                if c.startswith("-") or (" " in c):
+                    c = "(" + c + ")"
+                if i == 0:
+                    s.append("%s" % c)
+                elif i == 1:
+                    if c == "1":
+                        s.append("x")
+                    else:
+                        s.append("%s*x" % c)
+                else:
+                    if c == "1":
+                        s.append("x^%s" % i)
+                    else:
+                        s.append("%s*x^%s" % (c, i))
+        return " + ".join(s)
+
+    def roots(self):
+        """
+        Depreciated function.
+        
+        To recover roots of a polynomial, first convert to acb:
+
+        acb_poly(input_poly).roots()
+        """
+        warn('This method is deprecated.', DeprecationWarning)
+        
+
 
 cdef class flint_mpoly(flint_elem):
     """
     Base class for multivariate polynomials.
     """
+
 
 cdef class flint_series(flint_elem):
     """

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -68,7 +68,7 @@ cdef class flint_poly(flint_elem):
 
     def roots(self):
         """
-        Depreciated function.
+        Deprecated function.
         
         To recover roots of a polynomial, first convert to acb:
 

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -74,7 +74,7 @@ cdef class flint_poly(flint_elem):
 
         acb_poly(input_poly).roots()
         """
-        warn('This method is deprecated.', DeprecationWarning)
+        warn('This method is deprecated. Please instead use acb_poly(input_poly).roots()', DeprecationWarning)
         
 
 

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -1,5 +1,3 @@
-from warnings import warn
-
 from flint.flint_base.flint_context cimport thectx
 
 cdef class flint_elem:
@@ -74,7 +72,7 @@ cdef class flint_poly(flint_elem):
 
         acb_poly(input_poly).roots()
         """
-        warn('This method is deprecated. Please instead use acb_poly(input_poly).roots()', DeprecationWarning)
+        raise NotImplementedError('This method has been deprecated. Please instead use acb_poly(input_poly).roots()')
         
 
 

--- a/src/flint/fmpq.pyx
+++ b/src/flint/fmpq.pyx
@@ -1,4 +1,5 @@
 from flint.flint_base.flint_base cimport flint_scalar
+from flint.utils.typecheck cimport typecheck
 
 cdef any_as_fmpq(obj):
     if typecheck(obj, fmpq):

--- a/src/flint/fmpq_mat.pyx
+++ b/src/flint/fmpq_mat.pyx
@@ -1,4 +1,5 @@
 from flint.flint_base.flint_base cimport flint_mat
+from flint.utils.typecheck cimport typecheck
 
 cdef any_as_fmpq_mat(obj):
     if typecheck(obj, fmpq_mat):

--- a/src/flint/fmpq_poly.pyx
+++ b/src/flint/fmpq_poly.pyx
@@ -1,6 +1,5 @@
-# TODO: waiting for fix on the roots method, currently 
-# globally defined.
-# from flint.flint_base.flint_base cimport flint_poly
+from flint.utils.typecheck cimport typecheck
+from flint.flint_base.flint_base cimport flint_poly
 
 cdef any_as_fmpq_poly(obj):
     if typecheck(obj, fmpq_poly):

--- a/src/flint/fmpq_series.pyx
+++ b/src/flint/fmpq_series.pyx
@@ -1,4 +1,5 @@
 from flint.flint_base.flint_base cimport flint_series
+from flint.utils.typecheck cimport typecheck
 
 cdef fmpq_series_coerce_operands(x, y):
     if isinstance(y, (int, long, fmpz, fmpz_poly, fmpz_series, fmpq, fmpq_poly)):

--- a/src/flint/fmpz.pyx
+++ b/src/flint/fmpz.pyx
@@ -1,6 +1,7 @@
 from cpython.version cimport PY_MAJOR_VERSION
 
 from flint.flint_base.flint_base cimport flint_scalar
+from flint.utils.typecheck cimport typecheck
 from flint.utils.conversion cimport chars_from_str
 
 cdef inline int fmpz_set_pylong(fmpz_t x, obj):

--- a/src/flint/fmpz_mat.pyx
+++ b/src/flint/fmpz_mat.pyx
@@ -1,4 +1,5 @@
 from flint.flint_base.flint_base cimport flint_mat
+from flint.utils.typecheck cimport typecheck
 
 cdef any_as_fmpz_mat(obj):
     if typecheck(obj, fmpz_mat):

--- a/src/flint/fmpz_mpoly.pyx
+++ b/src/flint/fmpz_mpoly.pyx
@@ -1,6 +1,7 @@
 from cpython.version cimport PY_MAJOR_VERSION
 
 from flint.utils.conversion cimport str_from_chars
+from flint.utils.typecheck cimport typecheck
 from flint.flint_base.flint_base cimport flint_mpoly
 
 cdef any_as_fmpz_mpoly(x):

--- a/src/flint/fmpz_poly.pyx
+++ b/src/flint/fmpz_poly.pyx
@@ -1,9 +1,8 @@
 from cpython.version cimport PY_MAJOR_VERSION
 
 from flint.flint_base.flint_context cimport getprec
-# TODO: waiting for fix on the roots method, currently 
-# globally defined.
-# from flint.flint_base.flint_base cimport flint_poly
+from flint.flint_base.flint_base cimport flint_poly
+from flint.utils.typecheck cimport typecheck
 
 cdef any_as_fmpz_poly(x):
     cdef fmpz_poly res

--- a/src/flint/fmpz_series.pyx
+++ b/src/flint/fmpz_series.pyx
@@ -1,3 +1,4 @@
+from flint.utils.typecheck cimport typecheck
 from flint.flint_base.flint_base cimport flint_series
 
 cdef fmpz_series_coerce_operands(x, y):

--- a/src/flint/nmod.pyx
+++ b/src/flint/nmod.pyx
@@ -1,4 +1,5 @@
 from flint.flint_base.flint_base cimport flint_scalar
+from flint.utils.typecheck cimport typecheck
 
 cdef int any_as_nmod(mp_limb_t * val, obj, nmod_t mod) except -1:
     cdef int success

--- a/src/flint/nmod_mat.pyx
+++ b/src/flint/nmod_mat.pyx
@@ -1,4 +1,5 @@
 from flint.utils.conversion cimport matrix_to_str
+from flint.utils.typecheck cimport typecheck
 
 cdef any_as_nmod_mat(obj, nmod_t mod):
     cdef nmod_mat r

--- a/src/flint/nmod_poly.pyx
+++ b/src/flint/nmod_poly.pyx
@@ -1,6 +1,5 @@
-# TODO: waiting for fix on the roots method, currently 
-# globally defined.
-# from flint.flint_base.flint_base cimport flint_poly
+from flint.flint_base.flint_base cimport flint_poly
+from flint.utils.typecheck cimport typecheck
 
 cdef any_as_nmod_poly(obj, nmod_t mod):
     cdef nmod_poly r

--- a/src/flint/pyflint.pyx
+++ b/src/flint/pyflint.pyx
@@ -24,77 +24,11 @@ cdef extern from "Python.h":
     double PyComplex_RealAsDouble(PyObject *op)
     double PyComplex_ImagAsDouble(PyObject *op)
 
-cdef inline bint typecheck(object ob, object tp):
-    return PyObject_TypeCheck(ob, <PyTypeObject*>tp)
-
 DEF FMPZ_UNKNOWN = 0
 DEF FMPZ_REF = 1
 DEF FMPZ_TMP = 2
 
 ctx = thectx
-
-# TODO:
-# This should be factored out into flint_base
-# but we cannot do this until we can import 
-# acb_poly to allow the roots() method to remain
-
-from flint.flint_base.flint_base cimport flint_elem
-
-cdef class flint_poly(flint_elem):
-    """
-    Base class for polynomials.
-    """
-
-    def __iter__(self):
-        cdef long i, n
-        n = self.length()
-        for i in range(n):
-            yield self[i]
-
-    def coeffs(self):
-        return list(self)
-
-    def str(self, bint ascending=False):
-        """
-        Convert to a human-readable string (generic implementation for
-        all polynomial types).
-
-        If *ascending* is *True*, the monomials are output from low degree to
-        high, otherwise from high to low.
-        """
-        coeffs = [str(c) for c in self]
-        if not coeffs:
-            return "0"
-        s = []
-        coeffs = enumerate(coeffs)
-        if not ascending:
-            coeffs = reversed(list(coeffs))
-        for i, c in coeffs:
-            if c == "0":
-                continue
-            else:
-                if c.startswith("-") or (" " in c):
-                    c = "(" + c + ")"
-                if i == 0:
-                    s.append("%s" % c)
-                elif i == 1:
-                    if c == "1":
-                        s.append("x")
-                    else:
-                        s.append("%s*x" % c)
-                else:
-                    if c == "1":
-                        s.append("x^%s" % i)
-                    else:
-                        s.append("%s*x^%s" % (c, i))
-        return " + ".join(s)
-
-    def roots(self, **kwargs):
-        """
-        Isolates the complex roots of *self*. See :meth:`.acb_poly.roots`
-        for details.
-        """
-        return acb_poly(self).roots(**kwargs)
 
 include "fmpz.pyx"
 include "fmpz_poly.pyx"

--- a/src/flint/utils/typecheck.pxd
+++ b/src/flint/utils/typecheck.pxd
@@ -1,0 +1,4 @@
+from flint._flint cimport PyTypeObject, PyObject_TypeCheck
+
+cdef inline bint typecheck(object ob, object tp):
+    return PyObject_TypeCheck(ob, <PyTypeObject*>tp)


### PR DESCRIPTION
Just a few additional things I wanted to do before finishing what I started in #61, this PR in part addresses Issue #62 by depreciating roots in the general case and asks the user to first convert to `acb_poly()`