### PR TITLE
Add method to compute integer roots

### DIFF
--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -68,7 +68,10 @@ cdef class flint_poly(flint_elem):
         """
         Computes all the roots in the base ring of the polynomial.
         Returns a list of all pairs (*v*, *m*) where *v* is the 
-        integer root and *m* is the multiplicity of the root
+        integer root and *m* is the multiplicity of the root.
+
+        To compute complex roots of a polynomial, instead use
+        the `.complex_roots()` method.
 
             >>> from flint import fmpz_poly
             >>> fmpz_poly([1, 2]).roots()

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -66,14 +66,50 @@ cdef class flint_poly(flint_elem):
 
     def roots(self):
         """
-        Deprecated function.
-        
-        To recover roots of a polynomial, first convert to acb:
+        Computes all the roots in the base ring of the polynomial.
+        Returns a list of all pairs (*v*, *m*) where *v* is the 
+        integer root and *m* is the multiplicity of the root
 
-        acb_poly(input_poly).roots()
+            >>> from flint import fmpz_poly
+            >>> fmpz_poly([]).roots()
+            []
+            >>> fmpz_poly([1]).roots()
+            []
+            >>> fmpz_poly([2, 1]).roots()
+            [(-2, 1)]
+            >>> fmpz_poly([1, 2]).roots()
+            []
+            >>> fmpz_poly([12, 7, 1]).roots()
+            [(-3, 1), (-4, 1)]
+            >>> (fmpz_poly([1, 2]) *  fmpz_poly([-3,1]) *  fmpz_poly([1, 2, 3]) *  fmpz_poly([12, 7, 1])).roots()
+            [(-3, 1), (-4, 1), (3, 1)]
+            >>> from flint import nmod_poly
+            >>> nmod_poly([1], 11).roots()
+            []
+            >>> nmod_poly([1, 2, 3], 11).roots()
+            [(8, 1), (6, 1)]
+            >>> nmod_poly([1, 6, 1, 8], 11).roots()
+            [(5, 3)]
+            >>> from flint import fmpq_poly
+            >>> fmpq_poly([1,2]).roots()
+            [(-1/2, 1)]
+            >>> fmpq_poly([2,1]).roots()
+            [(-2, 1)]
+            >>> f = fmpq_poly([fmpq(1,3), fmpq(3,5)]) * fmpq_poly([fmpq(4,11), fmpq(9)])
+            >>> f.roots()
+            [(-4/99, 1), (-5/9, 1)]
         """
-        raise NotImplementedError('This method is no longer supported. To recover the complex roots first convert to acb_poly')
-        
+        factor_fn = getattr(self, "factor", None)
+        if not callable(factor_fn):
+            raise NotImplementedError("Polynomial has no factor method, roots cannot be determined")
+
+        roots = []
+        factors = self.factor()
+        for fac, m in factors[1]:
+            if fac.degree() == fac[1] == 1:
+                v = - fac[0]
+                roots.append((v, m))
+        return roots
 
 
 cdef class flint_mpoly(flint_elem):

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -71,33 +71,14 @@ cdef class flint_poly(flint_elem):
         integer root and *m* is the multiplicity of the root
 
             >>> from flint import fmpz_poly
-            >>> fmpz_poly([]).roots()
-            []
-            >>> fmpz_poly([1]).roots()
+            >>> fmpz_poly([1, 2]).roots()
             []
             >>> fmpz_poly([2, 1]).roots()
             [(-2, 1)]
-            >>> fmpz_poly([1, 2]).roots()
-            []
             >>> fmpz_poly([12, 7, 1]).roots()
             [(-3, 1), (-4, 1)]
-            >>> (fmpz_poly([1, 2]) *  fmpz_poly([-3,1]) *  fmpz_poly([1, 2, 3]) *  fmpz_poly([12, 7, 1])).roots()
-            [(-3, 1), (-4, 1), (3, 1)]
-            >>> from flint import nmod_poly
-            >>> nmod_poly([1], 11).roots()
-            []
-            >>> nmod_poly([1, 2, 3], 11).roots()
-            [(8, 1), (6, 1)]
-            >>> nmod_poly([1, 6, 1, 8], 11).roots()
-            [(5, 3)]
-            >>> from flint import fmpq_poly
-            >>> fmpq_poly([1,2]).roots()
-            [(-1/2, 1)]
-            >>> fmpq_poly([2,1]).roots()
-            [(-2, 1)]
-            >>> f = fmpq_poly([fmpq(1,3), fmpq(3,5)]) * fmpq_poly([fmpq(4,11), fmpq(9)])
-            >>> f.roots()
-            [(-4/99, 1), (-5/9, 1)]
+            >>> (fmpz_poly([-5,1]) * fmpz_poly([-5,1]) * fmpz_poly([-3,1])).roots()
+            [(3, 1), (5, 2)]
         """
         factor_fn = getattr(self, "factor", None)
         if not callable(factor_fn):

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -71,7 +71,8 @@ cdef class flint_poly(flint_elem):
         integer root and *m* is the multiplicity of the root.
 
         To compute complex roots of a polynomial, instead use
-        the `.complex_roots()` method.
+        the `.complex_roots()` method, which is available on
+        certain polynomial rings.
 
             >>> from flint import fmpz_poly
             >>> fmpz_poly([1, 2]).roots()
@@ -94,6 +95,9 @@ cdef class flint_poly(flint_elem):
                 v = - fac[0]
                 roots.append((v, m))
         return roots
+    
+    def complex_roots(self):
+        raise AttributeError("Complex roots are not supported for this polynomial")
 
 
 cdef class flint_mpoly(flint_elem):

--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -438,11 +438,17 @@ def test_fmpz_poly():
     assert Z([1,2,2]).sqrt() is None
     assert Z([1,0,2,0,3]).deflation() == (Z([1,2,3]), 2)
     assert Z([1,1]).deflation() == (Z([1,1]), 1)
-    [(r,m)] = Z([1,1]).roots()
+    [(r,m)] = Z([1,1]).complex_roots()
     assert m == 1
     assert r.overlaps(-1)
+    assert Z([]).complex_roots() == []
+    assert Z([1]).complex_roots() == []
+    [(r,m)] = Z([1,1]).roots()
+    assert m == 1
+    assert r == -1
     assert Z([]).roots() == []
     assert Z([1]).roots() == []
+    assert Z([1, 2]).roots() == []
 
 def test_fmpz_poly_factor():
     Z = flint.fmpz_poly
@@ -985,9 +991,9 @@ def test_fmpq_poly():
     assert Q.bernoulli_poly(3) == Q([0,1,-3,2],2)
     assert Q.euler_poly(3) == Q([1,0,-6,4],4)
     assert Q.legendre_p(3) == Q([0,-3,0,5],2)
-    assert Q([]).roots() == []
-    assert Q([1]).roots() == []
-    [(r,m)] = Q([1,1]).roots()
+    assert Q([]).complex_roots() == []
+    assert Q([1]).complex_roots() == []
+    [(r,m)] = Q([1,1]).complex_roots()
     assert m == 1
     assert r.overlaps(-1)
 

--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -996,6 +996,8 @@ def test_fmpq_poly():
     [(r,m)] = Q([1,1]).complex_roots()
     assert m == 1
     assert r.overlaps(-1)
+    assert str(Q([1,2]).roots()) == "[(-1/2, 1)]"
+    assert Q([2,1]).roots() == [(-2, 1)]
 
 def test_fmpq_mat():
     Q = flint.fmpq_mat
@@ -1417,6 +1419,9 @@ def test_nmod_poly():
     for alg in [None, 'berlekamp', 'cantor-zassenhaus']:
         assert p3.factor(alg) == f3
         assert p3.factor(algorithm=alg) == f3
+    assert P([1], 11).roots() == []
+    assert P([1, 2, 3], 11).roots() == [(8, 1), (6, 1)]
+    assert P([1, 6, 1, 8], 11).roots() == [(5, 3)]
 
 def test_nmod_mat():
     M = flint.nmod_mat

--- a/src/flint/types/acb_poly.pyx
+++ b/src/flint/types/acb_poly.pyx
@@ -412,6 +412,8 @@ cdef class acb_poly(flint_poly):
 
         return pyroots
 
+    complex_roots = roots
+
     def root_bound(self):
         """Returns an upper bound for the absolute value of
         the roots of self."""

--- a/src/flint/types/arb_poly.pyx
+++ b/src/flint/types/arb_poly.pyx
@@ -113,6 +113,13 @@ cdef class arb_poly(flint_poly):
         libc.stdlib.free(xs)
         return u
 
+    def complex_roots(self, **kwargs):
+        """
+        Compute the complex roots of the polynomial by converting 
+        from arb_poly to acb_poly
+        """
+        return acb_poly(self).roots(**kwargs)
+
     def evaluate(self, xs, algorithm='fast'):
         """
         Multipoint evaluation: evaluates *self* at the list of

--- a/src/flint/types/fmpq_poly.pyx
+++ b/src/flint/types/fmpq_poly.pyx
@@ -384,16 +384,16 @@ cdef class fmpq_poly(flint_poly):
             fac[i] = (base, exp)
         return c / self.denom(), fac
 
-    def roots(self, **kwargs):
+    def complex_roots(self, **kwargs):
         """
         Computes the complex roots of this polynomial. See
         :meth:`.fmpz_poly.roots`.
 
             >>> from flint import fmpq
-            >>> fmpq_poly([fmpq(2,3),1]).roots()
+            >>> fmpq_poly([fmpq(2,3),1]).complex_roots()
             [([-0.666666666666667 +/- 3.34e-16], 1)]
         """
-        return self.numer().roots(**kwargs)
+        return self.numer().complex_roots(**kwargs)
 
     @staticmethod
     def bernoulli_poly(n):

--- a/src/flint/types/fmpz_poly.pyx
+++ b/src/flint/types/fmpz_poly.pyx
@@ -345,17 +345,61 @@ cdef class fmpz_poly(flint_poly):
 
     def roots(self, bint verbose=False):
         """
-        Computes all the complex roots of this polynomial.
-        Returns a list of pairs (*c*, *m*) where *c* is the root
-        as an *acb* and *m* is the multiplicity of the root.
+        Computes all the integer roots of this polynomial.
+        Returns a list of all pairs (*v*, *m*) where *v* is the 
+        integer root and *m* is the multiplicity of the root
 
             >>> fmpz_poly([]).roots()
             []
             >>> fmpz_poly([1]).roots()
             []
-            >>> fmpz_poly([2,0,1]).roots()
+            >>> fmpz_poly([2, 1]).roots()
+            [(-2, 1)]
+            >>> fmpz_poly([1, 2]).roots()
+            []
+            >>> fmpz_poly([12, 7, 1]).roots()
+            [(-3, 1), (-4, 1)]
+            >>> (fmpz_poly([1, 2]) *  fmpz_poly([-3,1]) *  fmpz_poly([1, 2, 3]) *  fmpz_poly([12, 7, 1])).roots()
+            [(-3, 1), (-4, 1), (3, 1)]
+
+        """
+        cdef fmpz_poly_factor_t fac
+        cdef fmpz constant_coeff, linear_coeff
+        cdef long deg, i
+        cdef int exp
+
+        if not self:
+            return []
+
+        roots = []
+        constant_coeff = fmpz()        
+        linear_coeff = fmpz()
+
+        fmpz_poly_factor_init(fac)
+        fmpz_poly_factor(fac, self.val)
+        for 0 <= i < fac.num:
+            deg = fmpz_poly_degree(&fac.p[i])
+            fmpz_poly_get_coeff_fmpz(linear_coeff.val, &fac.p[i], 1)
+            if deg == 1 and linear_coeff == 1:
+                fmpz_poly_get_coeff_fmpz(constant_coeff.val, &fac.p[i], 0)
+                exp = fac.exp[i]
+                roots.append((-constant_coeff, exp))
+        fmpz_poly_factor_clear(fac)
+        return roots
+
+    def complex_roots(self, bint verbose=False):
+        """
+        Computes all the complex roots of this polynomial.
+        Returns a list of pairs (*c*, *m*) where *c* is the root
+        as an *acb* and *m* is the multiplicity of the root.
+
+            >>> fmpz_poly([]).complex_roots()
+            []
+            >>> fmpz_poly([1]).complex_roots()
+            []
+            >>> fmpz_poly([2,0,1]).complex_roots()
             [([1.41421356237310 +/- 4.96e-15]j, 1), ([-1.41421356237310 +/- 4.96e-15]j, 1)]
-            >>> for c, m in (fmpz_poly([2,3,4]) * fmpz_poly([5,6,7,11])**3).roots():
+            >>> for c, m in (fmpz_poly([2,3,4]) * fmpz_poly([5,6,7,11])**3).complex_roots():
             ...     print((c,m))
             ...
             ([-0.375000000000000 +/- 1.0e-19] + [0.599478940414090 +/- 5.75e-17]j, 1)

--- a/src/flint/types/fmpz_poly.pyx
+++ b/src/flint/types/fmpz_poly.pyx
@@ -343,50 +343,6 @@ cdef class fmpz_poly(flint_poly):
         fmpz_poly_factor_clear(fac)
         return c, res
 
-    def roots(self, bint verbose=False):
-        """
-        Computes all the integer roots of this polynomial.
-        Returns a list of all pairs (*v*, *m*) where *v* is the 
-        integer root and *m* is the multiplicity of the root
-
-            >>> fmpz_poly([]).roots()
-            []
-            >>> fmpz_poly([1]).roots()
-            []
-            >>> fmpz_poly([2, 1]).roots()
-            [(-2, 1)]
-            >>> fmpz_poly([1, 2]).roots()
-            []
-            >>> fmpz_poly([12, 7, 1]).roots()
-            [(-3, 1), (-4, 1)]
-            >>> (fmpz_poly([1, 2]) *  fmpz_poly([-3,1]) *  fmpz_poly([1, 2, 3]) *  fmpz_poly([12, 7, 1])).roots()
-            [(-3, 1), (-4, 1), (3, 1)]
-
-        """
-        cdef fmpz_poly_factor_t fac
-        cdef fmpz constant_coeff, linear_coeff
-        cdef long deg, i
-        cdef int exp
-
-        if not self:
-            return []
-
-        roots = []
-        constant_coeff = fmpz()        
-        linear_coeff = fmpz()
-
-        fmpz_poly_factor_init(fac)
-        fmpz_poly_factor(fac, self.val)
-        for 0 <= i < fac.num:
-            deg = fmpz_poly_degree(&fac.p[i])
-            fmpz_poly_get_coeff_fmpz(linear_coeff.val, &fac.p[i], 1)
-            if deg == 1 and linear_coeff == 1:
-                fmpz_poly_get_coeff_fmpz(constant_coeff.val, &fac.p[i], 0)
-                exp = fac.exp[i]
-                roots.append((-constant_coeff, exp))
-        fmpz_poly_factor_clear(fac)
-        return roots
-
     def complex_roots(self, bint verbose=False):
         """
         Computes all the complex roots of this polynomial.

--- a/src/flint/types/nmod.pyx
+++ b/src/flint/types/nmod.pyx
@@ -81,6 +81,12 @@ cdef class nmod(flint_scalar):
                 return res
             else:
                 return not res
+        elif typecheck(s, nmod) and typecheck(t, int):
+            res = s.val == (t % s.mod.n)
+            if op == 2:
+                return res
+            else:
+                return not res
         return NotImplemented
 
     def __nonzero__(self):


### PR DESCRIPTION
This is a work in progress. Currently both `fmpz_poly` and `fmpq_poly` have `.roots()` methods which return complex roots of the polynomial. The hope is to address issue #62.

This first set of commits renames these methods to `complex_roots()` and also introduces a new method to compute integer roots on `fmpz_poly()` which is named `.roots()`

I have updated and included a few more tests and added doctests to the new function.

If this is something the flint team like, I can add similar methods to `fmpq_poly` for rational roots and also look at the other polynomial classes.