### PR TITLE
Work around cython parameter passing bug.

### DIFF
--- a/src/flint/functions/showgood.pyx
+++ b/src/flint/functions/showgood.pyx
@@ -13,19 +13,18 @@ from flint.flintlib.acb cimport *
 
 ctx = thectx
 
-# xxx: this doesn't work when changed to a cdef function. why?
-def __goodness(x, bint parts=True, metric=None):
+cdef slong __goodness(x, bint parts, metric):
     if metric is not None:
         x = metric(x)
     if isinstance(x, arb):
         return arb_rel_accuracy_bits((<arb>x).val)
     if isinstance(x, acb):
         if parts:
-            return min(__goodness(x.real), __goodness(x.imag))
+            return min(__goodness(x.real, parts, metric), __goodness(x.imag, parts, metric))
         else:
             return acb_rel_accuracy_bits((<acb>x).val)
     if isinstance(x, (tuple, list, arb_mat, acb_mat, arb_poly, acb_poly, arb_series, acb_series)):
-        return min(__goodness(y, parts) for y in x)
+        return min(__goodness(y, parts, metric) for y in x)
     raise TypeError("must have arb or acb")
 
 cdef goodstr(x):

--- a/src/flint/test/__main__.py
+++ b/src/flint/test/__main__.py
@@ -73,7 +73,8 @@ def run_doctests(verbose=None):
                flint.types.acb_poly,
                flint.types.acb_mat,
                flint.types.acb_series,
-               flint.types.dirichlet]
+               flint.types.dirichlet,
+               flint.functions.showgood]
     results = [doctest.testmod(x) for x in modules]
 #    ffmpz, tfmpz = doctest.testmod(flint._fmpz, verbose=verbose)
  #   failed, total = doctest.testmod(flint.pyflint, verbose=verbose)


### PR DESCRIPTION
In the words of Mae West, "goodness had nothing to do with it".

In this case, she was wrong though, `__goodness` tickled a cython code generation bug if `__goodness` was compiled as a cdef function.

Made `__goodness` work as a cdef function by removing its default parameter values.

Boiling this down to a human comprehensible example suitable for a cython bug report is a work in progress.

It appears that cython has a bug in passing parameters with defaults to some recursive functions.  `__goodness` is one of them.  In this case if any of the parameters had defaults `parts` was passed a 0 (False).  Removing the defaults fixes this.

Also added the `showgood` submodule to the list of submodules to doctest.