### PR TITLE
Add fmpz mod

### DIFF
--- a/doc/source/fmpz_mod.rst
+++ b/doc/source/fmpz_mod.rst
@@ -1,5 +1,10 @@
-**fmpz** -- integers mod n
+**fmpz_mod** -- integers mod n
 ===============================================================================
+
+.. autoclass :: flint.fmpz_mod_ctx
+  :members:
+  :inherited-members:
+  :undoc-members:
 
 .. autoclass :: flint.fmpz_mod
   :members:

--- a/doc/source/fmpz_mod.rst
+++ b/doc/source/fmpz_mod.rst
@@ -1,7 +1,7 @@
-**nmod** -- integers mod wordsize n
+**fmpz** -- integers mod n
 ===============================================================================
 
-.. autoclass :: flint.nmod
+.. autoclass :: flint.fmpz_mod
   :members:
   :inherited-members:
   :undoc-members:

--- a/doc/source/general.rst
+++ b/doc/source/general.rst
@@ -161,8 +161,6 @@ determined from the available data.
 The following convenience functions are provided for numerical evaluation
 with adaptive working precision.
 
-.. autofunction :: flint.good
-
 .. autofunction :: flint.showgood
 
 Power series

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -43,6 +43,7 @@ Scalar types
 
    fmpz.rst
    fmpq.rst
+   fmpz_mod.rst
    nmod.rst
    arb.rst
    acb.rst

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ ext_files = [
     ("flint.types.acb_mat", ["src/flint/types/acb_mat.pyx"]),
     ("flint.types.acb_series", ["src/flint/types/acb_series.pyx"]),
     ("flint.types.fmpz_mpoly", ["src/flint/types/fmpz_mpoly.pyx"]),
+    ("flint.types.fmpz_mod", ["src/flint/types/fmpz_mod.pyx"]),
     ("flint.types.dirichlet", ["src/flint/types/dirichlet.pyx"]),
     ("flint.flint_base.flint_base", ["src/flint/flint_base/flint_base.pyx"]),
     ("flint.flint_base.flint_context", ["src/flint/flint_base/flint_context.pyx"]),

--- a/src/flint/__init__.py
+++ b/src/flint/__init__.py
@@ -21,6 +21,7 @@ from .types.acb_poly import *
 from .types.acb_mat import *
 from .types.acb_series import *
 from .types.fmpz_mpoly import *
+from .types.fmpz_mod import *
 from .functions.showgood import showgood
 
 __version__ = '0.4.4'

--- a/src/flint/__init__.py
+++ b/src/flint/__init__.py
@@ -22,6 +22,7 @@ from .types.acb_mat import *
 from .types.acb_series import *
 from .types.fmpz_mpoly import *
 from .types.fmpz_mod import *
+from .types.dirichlet import *
 from .functions.showgood import showgood
 
 __version__ = '0.4.4'

--- a/src/flint/flintlib/fmpz.pxd
+++ b/src/flint/flintlib/fmpz.pxd
@@ -1,11 +1,14 @@
-from flint.flintlib.flint cimport fmpz_struct, ulong, mp_limb_t
+from flint.flintlib.flint cimport fmpz_struct, ulong, mp_limb_t, mp_ptr
 from flint.flintlib.flint cimport mp_size_t, mp_bitcnt_t, slong, flint_rand_t, flint_bitcnt_t
-# from flint.flintlib.nmod cimport nmod_t
-# from flint.flintlib.fmpz_factor cimport fmpz_factor_t
 
 cdef extern from "flint/fmpz.h":
     ctypedef fmpz_struct fmpz_t[1]
 
+    ctypedef struct fmpz_preinvn_struct:
+        mp_ptr dinv
+        slong n
+        flint_bitcnt_t norm
+    ctypedef fmpz_preinvn_struct fmpz_preinvn_t[1]
 
 # from here on is parsed
     # fmpz_struct PTR_TO_COEFF(__mpz_struct * ptr)

--- a/src/flint/flintlib/fmpz_mod.pxd
+++ b/src/flint/flintlib/fmpz_mod.pxd
@@ -1,0 +1,45 @@
+from flint.flintlib.flint cimport ulong, slong
+from flint.flintlib.fmpz cimport fmpz_t, fmpz_preinvn_struct
+from flint.flintlib.nmod cimport nmod_t
+
+# unimported types  {'fmpz_mod_discrete_log_pohlig_hellman_t'}
+
+cdef extern from "flint/fmpz_mod.h":
+    ctypedef struct fmpz_mod_ctx_struct:
+        fmpz_t n
+        nmod_t mod
+        ulong n_limbs[3]
+        ulong ninv_limbs[3]
+        fmpz_preinvn_struct * ninv_huge
+    ctypedef fmpz_mod_ctx_struct fmpz_mod_ctx_t[1]
+
+    # Parsed from here
+    void fmpz_mod_ctx_init(fmpz_mod_ctx_t ctx, const fmpz_t n)
+    void fmpz_mod_ctx_clear(fmpz_mod_ctx_t ctx)
+    void fmpz_mod_ctx_set_modulus(fmpz_mod_ctx_t ctx, const fmpz_t n)
+    void fmpz_mod_set_fmpz(fmpz_t a, const fmpz_t b, const fmpz_mod_ctx_t ctx)
+    int fmpz_mod_is_canonical(const fmpz_t a, const fmpz_mod_ctx_t ctx)
+    int fmpz_mod_is_one(const fmpz_t a, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_add(fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_add_fmpz(fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_add_ui(fmpz_t a, const fmpz_t b, ulong c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_add_si(fmpz_t a, const fmpz_t b, slong c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_sub(fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_sub_fmpz(fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_sub_ui(fmpz_t a, const fmpz_t b, ulong c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_sub_si(fmpz_t a, const fmpz_t b, slong c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_fmpz_sub(fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_ui_sub(fmpz_t a, ulong b, const fmpz_t c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_si_sub(fmpz_t a, slong b, const fmpz_t c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_neg(fmpz_t a, const fmpz_t b, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_mul(fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_inv(fmpz_t a, const fmpz_t b, const fmpz_mod_ctx_t ctx)
+    int fmpz_mod_divides(fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_pow_ui(fmpz_t a, const fmpz_t b, ulong e, const fmpz_mod_ctx_t ctx)
+    int fmpz_mod_pow_fmpz(fmpz_t a, const fmpz_t b, const fmpz_t e, const fmpz_mod_ctx_t ctx)
+    # void fmpz_mod_discrete_log_pohlig_hellman_init(fmpz_mod_discrete_log_pohlig_hellman_t L)
+    # void fmpz_mod_discrete_log_pohlig_hellman_clear(fmpz_mod_discrete_log_pohlig_hellman_t L)
+    # double fmpz_mod_discrete_log_pohlig_hellman_precompute_prime(fmpz_mod_discrete_log_pohlig_hellman_t L, const fmpz_t p)
+    # const fmpz_struct * fmpz_mod_discrete_log_pohlig_hellman_primitive_root(const fmpz_mod_discrete_log_pohlig_hellman_t L)
+    # void fmpz_mod_discrete_log_pohlig_hellman_run(fmpz_t x, const fmpz_mod_discrete_log_pohlig_hellman_t L, const fmpz_t y)
+    int fmpz_next_smooth_prime(fmpz_t a, const fmpz_t b)

--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -1585,7 +1585,7 @@ def test_pickling():
         assert obj == obj2
 
 def test_fmpz_mod():
-    from flint import fmpz_mod_ctx
+    from flint import fmpz_mod_ctx, fmpz
 
     # Context tests
     F163 = fmpz_mod_ctx(163)
@@ -1634,8 +1634,19 @@ def test_fmpz_mod():
     # Addition
     assert F163(123) + F163(456) == F163(123 + 456)
     assert F163(123) + F163(456) == F163(456) + F163(123)
+    assert F163(123) + 456 == F163(123 + 456)
+    assert F163(123) + fmpz(456) == F163(456) + F163(123)
+
     test_inplace = F163(123) 
     test_inplace += F163(456) 
+    assert test_inplace == F163(123 + 456)
+
+    test_inplace = F163(123) 
+    test_inplace += 456
+    assert test_inplace == F163(123 + 456)
+
+    test_inplace = F163(123) 
+    test_inplace += fmpz(456)
     assert test_inplace == F163(123 + 456)
     
 

--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -1586,15 +1586,21 @@ def test_pickling():
 
 def test_fmpz_mod():
     from flint import fmpz_mod_ctx, fmpz
-
+    
     # Context tests
     F163 = fmpz_mod_ctx(163)
     assert F163.modulus() == 163
+
     big = 2**1024 - 1
     Fbig = fmpz_mod_ctx(2**1024 - 1)
     assert Fbig.modulus() == big
 
     # Rich comparisons 
+    assert raises(lambda: F163(123) > 0, TypeError)
+    assert raises(lambda: F163(123) >= 0, TypeError)
+    assert raises(lambda: F163(123) < 0, TypeError)
+    assert raises(lambda: F163(123) <= 0, TypeError)
+
     assert (F163(123) == 123) is True
     assert (F163(123) == 123 + 163) is True
     assert (F163(123) == 1) is False
@@ -1604,15 +1610,6 @@ def test_fmpz_mod():
     assert (F163(123) == F163(123 + 163)) is True
     assert (F163(123) == F163(1)) is False
     assert (F163(123) != F163(1)) is True
-
-    assert (Fbig(123) == 123) is True
-    assert (Fbig(123) == 123 + big) is True
-    assert (Fbig(123) == 1) is False
-    assert (Fbig(123) != 1) is True
-    assert (Fbig(123) == Fbig(123)) is True
-    assert (Fbig(123) == Fbig(123 + big)) is True
-    assert (Fbig(123) == Fbig(1)) is False
-    assert (Fbig(123) != Fbig(1)) is True
 
     # Is one, zero, canoncial
     assert (F163(0) == 0) is True
@@ -1625,6 +1622,7 @@ def test_fmpz_mod():
     assert F163(2).is_one() is False
     assert F163(123).is_canonical() is True
 
+
     # Arithmetic tests
 
     # Negation
@@ -1635,6 +1633,7 @@ def test_fmpz_mod():
     assert F163(123) + F163(456) == F163(123 + 456)
     assert F163(123) + F163(456) == F163(456) + F163(123)
     assert F163(123) + 456 == F163(123 + 456)
+    assert 456 + F163(123) == F163(123 + 456)
     assert F163(123) + fmpz(456) == F163(456) + F163(123)
     assert raises(lambda: F163(123) + Fbig(456), ValueError)
 
@@ -1649,6 +1648,102 @@ def test_fmpz_mod():
     test_inplace = F163(123) 
     test_inplace += fmpz(456)
     assert test_inplace == F163(123 + 456)
+
+    # Subtraction
+
+    assert F163(123) - F163(456) == F163(123 - 456)
+    assert F163(123) - 456 == F163(123 - 456)
+    assert F163(123) - 456 == F163(123) - F163(456)
+    assert F163(456) - 123 == F163(456) - F163(123)
+    assert 123 - F163(456) == F163(123) - F163(456)
+    # assert 456 - F163(123) == F163(456) - F163(123)
+    assert F163(123) - fmpz(456) == F163(123) - F163(456)
+    assert raises(lambda: F163(123) - Fbig(456), ValueError)
+
+    test_inplace = F163(123) 
+    test_inplace -= F163(456) 
+    assert test_inplace == F163(123 - 456)
+
+    test_inplace = F163(123) 
+    test_inplace -= 456
+    assert test_inplace == F163(123 - 456)
+
+    test_inplace = F163(123) 
+    test_inplace -= fmpz(456)
+    assert test_inplace == F163(123 - 456)
+
+    # Multiplication
+
+    assert F163(123) * F163(456) == (123 * 456) % 163
+    assert F163(123) * 456 == (123 * 456) % 163
+    assert 456 * F163(123) == (123 * 456) % 163
+
+    assert F163(1) * F163(123) == F163(1 * 123)
+    assert F163(2) * F163(123) == F163(2 * 123)
+    assert F163(3) * F163(123) == F163(3 * 123)
+    assert 1 * F163(123) == F163(1 * 123)
+    assert 2 * F163(123) == F163(2 * 123)
+    assert 3 * F163(123) == F163(3 * 123)
+    assert F163(123) * 1 == F163(1 * 123)
+    assert F163(123) * 2 == F163(2 * 123)
+    assert F163(123) * 3 == F163(3 * 123)
+    assert fmpz(1) * F163(123) == F163(1 * 123)
+    assert fmpz(2) * F163(123) == F163(2 * 123)
+    assert fmpz(3) * F163(123) == F163(3 * 123)
+
+    test_inplace = F163(123) 
+    test_inplace *= F163(456) 
+    assert test_inplace == F163(123 * 456)
+
+    test_inplace = F163(123) 
+    test_inplace *= 456
+    assert test_inplace == F163(123 * 456)
+
+    test_inplace = F163(123) 
+    test_inplace *= fmpz(456)
+    assert test_inplace == F163(123 * 456)
+
+    # Exponentiation 
+
+    assert F163(0)**0 == pow(0, 0, 163)
+    assert F163(0)**1 == pow(0, 1, 163)
+    assert F163(0)**2 == pow(0, 2, 163)
+    assert raises(lambda: F163(0)**(-1), ZeroDivisionError)
+
+    assert F163(123)**0 == pow(123, 0, 163)
+    assert F163(123)**1 == pow(123, 1, 163)
+    assert F163(123)**2 == pow(123, 2, 163)
+    assert F163(123)**3 == pow(123, 3, 163)
+    assert F163(123)**100 == pow(123, 100, 163)
+    assert F163(123)**(-1) == pow(123, -1, 163)
+    assert F163(123)**(-2) == pow(123, -2, 163)
+    assert F163(123)**(-3) == pow(123, -3, 163)
+    assert F163(123)**(-4) == pow(123, -4, 163)
+
+    # Inversion
+
+    assert raises(lambda: F163(0).__invert__(), ZeroDivisionError)
+    assert F163(123).__invert__() == pow(123, -1, 163)
+    assert F163(1).__invert__() == pow(1, -1, 163)
+    assert F163(2).__invert__() == pow(2, -1, 163)
+
+    assert F163(1).inverse(check=False) == pow(1, -1, 163)
+    assert F163(2).inverse(check=False) == pow(2, -1, 163)
+    assert F163(123).inverse(check=False) == pow(123, -1, 163)
+
+    # Division
+
+    assert raises(lambda: F163(1) / F163(0), ZeroDivisionError)
+    assert F163(123) / F163(456) == (123 * pow(456, -1, 163)) % 163
+    assert F163(123) / fmpz(456) == (123 * pow(456, -1, 163)) % 163
+    assert F163(123) / 456 == (123 * pow(456, -1, 163)) % 163
+
+    assert 1 / F163(2) ==  pow(2, -1, 163)
+    assert 1 / F163(123) ==  pow(123, -1, 163)
+    assert 1 / F163(456) ==  pow(456, -1, 163)
+
+    assert fmpz(456) / F163(123) == (456 * pow(123, -1, 163)) % 163
+    assert 456 / F163(123) == (456 * pow(123, -1, 163)) % 163
     
 
 all_tests = [

--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -1584,6 +1584,52 @@ def test_pickling():
         obj2 = pickle.loads(s)
         assert obj == obj2
 
+def test_fmpz_mod():
+    from flint import fmpz_mod_ctx
+
+    # Context tests
+    F163 = fmpz_mod_ctx(163)
+    assert F163.modulus() == 163
+    big = 2**1024 - 1
+    Fbig = fmpz_mod_ctx(2**1024 - 1)
+    assert Fbig.modulus() == big
+
+    # Rich comparisons 
+    assert raises(lambda: F163(123) > 0, TypeError)
+    assert raises(lambda: F163(123) >= 0, TypeError)
+    assert raises(lambda: F163(123) < 0, TypeError)
+    assert raises(lambda: F163(123) <= 0, TypeError)
+
+    assert F163(123) == 123
+    assert F163(123) == 123 + 163
+    assert F163(123) != 1
+    assert F163(123) == F163(123)
+    assert F163(123) == F163(123 + 163)
+    assert F163(123) != F163(1)
+
+    # Is one, zero, canoncial
+    assert F163(0) == 0
+    assert F163(0).is_zero()
+    assert not F163(0)
+    assert not F163(163)
+    assert F163(1).is_one()
+    assert F163(164).is_one()
+    assert not F163(2).is_one()
+    assert F163(123).is_canonical()
+
+    # Arithmetic tests
+
+    # Negation
+    assert -F163(123) == F163(-123) == (-123 % 163)
+    assert -F163(1) == F163(-1) == F163(162)
+
+    # Addition
+    assert F163(123) + F163(456) == F163(123 + 456)
+    assert F163(123) + F163(456) == F163(456) + F163(123)
+    test_inplace = F163(123) 
+    test_inplace += F163(456) 
+    assert test_inplace == F163(123 + 456)
+    
 
 all_tests = [
     test_pyflint,
@@ -1603,4 +1649,5 @@ all_tests = [
     test_nmod_poly,
     test_nmod_mat,
     test_arb,
+    test_fmpz_mod,
 ]

--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -1595,6 +1595,14 @@ def test_fmpz_mod():
     Fbig = fmpz_mod_ctx(2**1024 - 1)
     assert Fbig.modulus() == big
 
+    F163_copy = fmpz_mod_ctx(163)
+    assert F163_copy == F163
+    assert F163_copy != Fbig
+    assert str(F163) == "fmpz_mod_ctx(163)"
+    assert repr(F163) == "Context for fmpz_mod with modulus: 163"
+
+    # Type tests
+
     # Rich comparisons 
     assert raises(lambda: F163(123) > 0, TypeError)
     assert raises(lambda: F163(123) >= 0, TypeError)
@@ -1605,11 +1613,19 @@ def test_fmpz_mod():
     assert (F163(123) == 123 + 163) is True
     assert (F163(123) == 1) is False
     assert (F163(123) != 1) is True
-
     assert (F163(123) == F163(123)) is True
     assert (F163(123) == F163(123 + 163)) is True
     assert (F163(123) == F163(1)) is False
     assert (F163(123) != F163(1)) is True
+
+    assert (hash(F163(123)) == hash(123)) is True
+    assert (hash(F163(F163(123))) == hash(123)) is True
+    assert (hash(F163(123)) == hash(1)) is False
+    assert (hash(F163(123)) != hash(1)) is True
+    assert (hash(F163(123)) == hash(F163(123))) is True
+    assert (hash(F163(123)) == hash(F163(123 + 163))) is True
+    assert (hash(F163(123)) == hash(F163(1))) is False
+    assert (hash(F163(123)) != hash(F163(1))) is True
 
     # Is one, zero, canoncial
     assert (F163(0) == 0) is True
@@ -1620,8 +1636,14 @@ def test_fmpz_mod():
     assert F163(164).is_one() is True
     assert F163(1).is_one() is True
     assert F163(2).is_one() is False
-    assert F163(123).is_canonical() is True
 
+    # int, str, repr
+    assert str(F163(11)) == "11"
+    assert repr(F163(-1)) == "162"
+    assert repr(F163(11)) == "fmpz_mod(11, 163)"
+    assert repr(F163(-1)) == "fmpz_mod(162, 163)"
+
+    assert F163(5).__pos__() == F163(5)
 
     # Arithmetic tests
 
@@ -1631,6 +1653,8 @@ def test_fmpz_mod():
 
     # Addition
     assert F163(123) + F163(456) == F163(123 + 456)
+    assert raises(lambda: F163(123) + "AAA", TypeError)
+
     assert F163(123) + F163(456) == F163(456) + F163(123)
     assert F163(123) + 456 == F163(123 + 456)
     assert 456 + F163(123) == F163(123 + 456)

--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -1585,10 +1585,12 @@ def test_pickling():
         assert obj == obj2
 
 def test_fmpz_mod():
-    from flint import fmpz_mod_ctx, fmpz
+    from flint import fmpz_mod_ctx, fmpz, fmpz_mod
     
     # Context tests
     F163 = fmpz_mod_ctx(163)
+    assert raises(lambda: fmpz_mod_ctx("AAA"), NotImplementedError)
+    assert raises(lambda: fmpz_mod_ctx(-1), ValueError)
     assert F163.modulus() == 163
 
     big = 2**1024 - 1
@@ -1597,11 +1599,19 @@ def test_fmpz_mod():
 
     F163_copy = fmpz_mod_ctx(163)
     assert F163_copy == F163
+    assert Fbig != F163
+    assert hash(F163_copy) == hash(F163)
+    assert hash(Fbig) != hash(F163), f"{hash(Fbig)}, {hash(F163)}"
     assert F163_copy != Fbig
+    assert F163_copy != "A"
+
     assert str(F163) == "fmpz_mod_ctx(163)"
     assert repr(F163) == "Context for fmpz_mod with modulus: 163"
 
     # Type tests
+
+    assert raises(lambda: fmpz_mod(1, "AAA"), ValueError)
+
 
     # Rich comparisons 
     assert raises(lambda: F163(123) > 0, TypeError)
@@ -1639,7 +1649,7 @@ def test_fmpz_mod():
 
     # int, str, repr
     assert str(F163(11)) == "11"
-    assert repr(F163(-1)) == "162"
+    assert str(F163(-1)) == "162"
     assert repr(F163(11)) == "fmpz_mod(11, 163)"
     assert repr(F163(-1)) == "fmpz_mod(162, 163)"
 
@@ -1653,6 +1663,8 @@ def test_fmpz_mod():
 
     # Addition
     assert F163(123) + F163(456) == F163(123 + 456)
+    assert F163(123) + F163_copy(456) == F163(123 + 456)
+    assert F163(123) + F163(456) == F163_copy(123 + 456)
     assert raises(lambda: F163(123) + "AAA", TypeError)
 
     assert F163(123) + F163(456) == F163(456) + F163(123)
@@ -1680,9 +1692,11 @@ def test_fmpz_mod():
     assert F163(123) - 456 == F163(123) - F163(456)
     assert F163(456) - 123 == F163(456) - F163(123)
     assert 123 - F163(456) == F163(123) - F163(456)
-    # assert 456 - F163(123) == F163(456) - F163(123)
+    assert 456 - F163(123) == F163(456) - F163(123)
     assert F163(123) - fmpz(456) == F163(123) - F163(456)
     assert raises(lambda: F163(123) - Fbig(456), ValueError)
+    assert raises(lambda: F163(123) - "AAA", TypeError)
+
 
     test_inplace = F163(123) 
     test_inplace -= F163(456) 
@@ -1714,6 +1728,8 @@ def test_fmpz_mod():
     assert fmpz(1) * F163(123) == F163(1 * 123)
     assert fmpz(2) * F163(123) == F163(2 * 123)
     assert fmpz(3) * F163(123) == F163(3 * 123)
+    assert raises(lambda: F163(123) * "AAA", TypeError)
+
 
     test_inplace = F163(123) 
     test_inplace *= F163(456) 
@@ -1733,6 +1749,8 @@ def test_fmpz_mod():
     assert F163(0)**1 == pow(0, 1, 163)
     assert F163(0)**2 == pow(0, 2, 163)
     assert raises(lambda: F163(0)**(-1), ZeroDivisionError)
+    assert raises(lambda: F163(0)**("AA"), NotImplementedError)
+
 
     assert F163(123)**0 == pow(123, 0, 163)
     assert F163(123)**1 == pow(123, 1, 163)
@@ -1761,7 +1779,10 @@ def test_fmpz_mod():
     assert F163(123) / F163(456) == (123 * pow(456, -1, 163)) % 163
     assert F163(123) / fmpz(456) == (123 * pow(456, -1, 163)) % 163
     assert F163(123) / 456 == (123 * pow(456, -1, 163)) % 163
-
+    assert raises(lambda: F163(123) / "AAA", TypeError)
+    assert raises(lambda: "AAA" / F163(123), TypeError)
+    assert raises(lambda: Fbig(123) / F163(123), ValueError)
+    assert raises(lambda: F163(123) // F163(123), TypeError)
     assert 1 / F163(2) ==  pow(2, -1, 163)
     assert 1 / F163(123) ==  pow(123, -1, 163)
     assert 1 / F163(456) ==  pow(456, -1, 163)

--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -1595,27 +1595,35 @@ def test_fmpz_mod():
     assert Fbig.modulus() == big
 
     # Rich comparisons 
-    assert raises(lambda: F163(123) > 0, TypeError)
-    assert raises(lambda: F163(123) >= 0, TypeError)
-    assert raises(lambda: F163(123) < 0, TypeError)
-    assert raises(lambda: F163(123) <= 0, TypeError)
+    assert (F163(123) == 123) is True
+    assert (F163(123) == 123 + 163) is True
+    assert (F163(123) == 1) is False
+    assert (F163(123) != 1) is True
 
-    assert F163(123) == 123
-    assert F163(123) == 123 + 163
-    assert F163(123) != 1
-    assert F163(123) == F163(123)
-    assert F163(123) == F163(123 + 163)
-    assert F163(123) != F163(1)
+    assert (F163(123) == F163(123)) is True
+    assert (F163(123) == F163(123 + 163)) is True
+    assert (F163(123) == F163(1)) is False
+    assert (F163(123) != F163(1)) is True
+
+    assert (Fbig(123) == 123) is True
+    assert (Fbig(123) == 123 + big) is True
+    assert (Fbig(123) == 1) is False
+    assert (Fbig(123) != 1) is True
+    assert (Fbig(123) == Fbig(123)) is True
+    assert (Fbig(123) == Fbig(123 + big)) is True
+    assert (Fbig(123) == Fbig(1)) is False
+    assert (Fbig(123) != Fbig(1)) is True
 
     # Is one, zero, canoncial
-    assert F163(0) == 0
-    assert F163(0).is_zero()
+    assert (F163(0) == 0) is True
+    assert F163(0).is_zero() is True
     assert not F163(0)
     assert not F163(163)
-    assert F163(1).is_one()
-    assert F163(164).is_one()
-    assert not F163(2).is_one()
-    assert F163(123).is_canonical()
+    assert F163(1).is_one() is True
+    assert F163(164).is_one() is True
+    assert F163(1).is_one() is True
+    assert F163(2).is_one() is False
+    assert F163(123).is_canonical() is True
 
     # Arithmetic tests
 

--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -1636,6 +1636,7 @@ def test_fmpz_mod():
     assert F163(123) + F163(456) == F163(456) + F163(123)
     assert F163(123) + 456 == F163(123 + 456)
     assert F163(123) + fmpz(456) == F163(456) + F163(123)
+    assert raises(lambda: F163(123) + Fbig(456), ValueError)
 
     test_inplace = F163(123) 
     test_inplace += F163(456) 

--- a/src/flint/types/fmpz.pxd
+++ b/src/flint/types/fmpz.pxd
@@ -10,6 +10,7 @@ from flint.flintlib.fmpz cimport fmpz_t, fmpz_set_str, fmpz_set_si
 from cpython.version cimport PY_MAJOR_VERSION
 
 cdef int fmpz_set_any_ref(fmpz_t x, obj)
+cdef fmpz_get_intlong(fmpz_t x)
 
 cdef inline int fmpz_set_pylong(fmpz_t x, obj):
     cdef int overflow

--- a/src/flint/types/fmpz_mod.pxd
+++ b/src/flint/types/fmpz_mod.pxd
@@ -1,0 +1,11 @@
+from flint.flint_base.flint_base cimport flint_scalar
+from flint.flintlib.fmpz cimport fmpz_t
+from flint.flintlib.fmpz_mod cimport fmpz_mod_ctx_t
+
+cdef class fmpz_mod_ctx:
+    cdef fmpz_mod_ctx_t val
+
+cdef class fmpz_mod(flint_scalar):
+    cdef fmpz_t val
+    cdef fmpz_mod_ctx ctx
+

--- a/src/flint/types/fmpz_mod.pxd
+++ b/src/flint/types/fmpz_mod.pxd
@@ -2,10 +2,11 @@ from flint.flint_base.flint_base cimport flint_scalar
 from flint.flintlib.fmpz cimport fmpz_t
 from flint.flintlib.fmpz_mod cimport fmpz_mod_ctx_t
 
+
 cdef class fmpz_mod_ctx:
     cdef fmpz_mod_ctx_t val
 
 cdef class fmpz_mod(flint_scalar):
-    cdef fmpz_t val
     cdef fmpz_mod_ctx ctx
+    cdef fmpz_t val
 

--- a/src/flint/types/fmpz_mod.pxd
+++ b/src/flint/types/fmpz_mod.pxd
@@ -10,3 +10,5 @@ cdef class fmpz_mod(flint_scalar):
     cdef fmpz_mod_ctx ctx
     cdef fmpz_t val
 
+    cdef any_as_fmpz_mod(self, obj)
+

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -176,18 +176,52 @@ cdef class fmpz_mod(flint_scalar):
     # TODO: proper type handing for the other...
     def __add__(self, other):
         res = fmpz()
-        fmpz_mod_add(
-            res.val, self.val, (<fmpz_mod>other).val, 
+
+        # Add two fmpz_mod if moduli match
+        if typecheck(other, fmpz_mod):
+            if not (self).ctx.modulus() == (<fmpz_mod>other).ctx.modulus():
+                raise ValueError("moduli must match")
+
+            fmpz_mod_add(
+                res.val, self.val, (<fmpz_mod>other).val, 
+                (<fmpz_mod_ctx_t>self.ctx.val)
+            )
+            return self.ctx(res)
+
+        other = any_as_fmpz(other)
+        if other is NotImplemented:
+            raise NotImplementedError
+
+        # Add an fmpz to an fmpz_mod
+        fmpz_mod_add_fmpz(
+            res.val, self.val, (<fmpz>other).val, 
             (<fmpz_mod_ctx_t>self.ctx.val)
         )
+
         return self.ctx(res)
 
     def __radd__(self, other):
         return other + self
 
     def __iadd__(self, other):
-        fmpz_mod_add(
-            self.val, self.val, (<fmpz_mod>other).val, 
+        # Add two fmpz_mod if moduli match
+        if typecheck(other, fmpz_mod):
+            if not (self).ctx.modulus() == (<fmpz_mod>other).ctx.modulus():
+                raise ValueError("moduli must match")
+
+            fmpz_mod_add(
+                self.val, self.val, (<fmpz_mod>other).val, 
+                (<fmpz_mod_ctx_t>self.ctx.val)
+            )
+            return self
+
+        # Add an fmpz to an fmpz_mod
+        other = any_as_fmpz(other)
+        if other is NotImplemented:
+            raise NotImplementedError
+
+        fmpz_mod_add_fmpz(
+            self.val, self.val, (<fmpz>other).val, 
             (<fmpz_mod_ctx_t>self.ctx.val)
         )
         return self

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -1,0 +1,49 @@
+from flint.flint_base.flint_base cimport flint_scalar
+from flint.flintlib.fmpz_mod cimport (
+    fmpz_mod_ctx_init,
+    fmpz_mod_ctx_set_modulus,
+)
+
+from flint.types.fmpz cimport fmpz, any_as_fmpz
+
+cdef class fmpz_mod_ctx:
+    """
+    """
+    def __init__(self, n):
+        """
+        """
+        # Ensure modulus is fmpz type
+        mod = any_as_fmpz(n)
+        if mod is NotImplemented:
+            raise NotImplementedError("TODO")
+
+        # Ensure modulus is positive
+        if mod < 1:
+            raise ValueError("Modulus is expected to be positive")
+
+        # Init the context
+        fmpz_mod_ctx_init(self.val, (<fmpz>mod).val)
+
+    def __repr__(self):
+        # return "Context for fmpz_mod with modulus: %s" % self.ctx.n
+        return "Stuff: (%s, %s, %s)" % (self.val.n, self.val.mod, self.val.n_limbs)
+
+    def __str__(self):
+        return "fmpz_mod_ctx(%s)" % self.val.mod
+
+    def set_modulus(self, n):
+        """
+        """
+        # Ensure modulus is fmpz type
+        mod = any_as_fmpz(n)
+        if mod is NotImplemented:
+            raise NotImplementedError("TODO")
+
+        # Ensure modulus is positive
+        if mod < 1:
+            raise ValueError("Modulus is expected to be positive")
+
+        fmpz_mod_ctx_set_modulus(self.val, (<fmpz>mod).val)
+
+cdef class fmpz_mod(flint_scalar):
+    pass

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -19,14 +19,14 @@ from flint.types.fmpz cimport (
 
 cdef class fmpz_mod_ctx:
     """
-    Context object for *fmpz_mod* initalised with a modulus `n`
+    Context object for creating :class:`~.fmpz_mod` initalised 
+    with a modulus `n`
 
         >>> fmpz_mod_ctx(2**127 - 1)
         fmpz_mod_ctx(170141183460469231731687303715884105727)
 
     """
     def __cinit__(self):
-        # TODO: is this the best method?
         cdef fmpz one = fmpz.__new__(fmpz)
         fmpz_one(one.val)
         fmpz_mod_ctx_init(self.val, one.val)
@@ -83,10 +83,17 @@ cdef class fmpz_mod(flint_scalar):
     """
     The *fmpz_mod* type represents integer modulo an 
     arbitrary-size modulus. For wordsize modulus, see
-    *nmod*.
+    :class:`~.nmod`.
+
+    An *fmpz_mod* element is constructed from an :class:`~.fmpz_mod_ctx`
+    either by passing it as an argument to the type, or
+    by directly calling the context
 
         >>> fmpz_mod(-1, fmpz_mod_ctx(2**127 - 1))
         fmpz_mod(170141183460469231731687303715884105726, 170141183460469231731687303715884105727)
+        >>> ZmodN = fmpz_mod_ctx(2**127 - 1)
+        >>> ZmodN(-2)
+        fmpz_mod(170141183460469231731687303715884105725, 170141183460469231731687303715884105727)
 
     """
 

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -6,7 +6,8 @@ from flint.flintlib.fmpz cimport (
     COEFF_IS_MPZ,
     fmpz_get_str,
     fmpz_init,
-    fmpz_clear
+    fmpz_clear,
+    fmpz_equal
 )
 from flint.flintlib.fmpz_mod cimport *
 
@@ -59,11 +60,6 @@ cdef class fmpz_mod_ctx:
 
         # Init the context
         fmpz_mod_ctx_init(self.val, (<fmpz>mod).val)
-
-    def __eq__(self, other):
-        if typecheck(other, fmpz_mod_ctx):
-            return self.val.n == (<fmpz_mod_ctx>other).val.n
-        return False
     
     def modulus(self):
         """
@@ -73,6 +69,14 @@ cdef class fmpz_mod_ctx:
         n = fmpz()
         fmpz_set(n.val, (<fmpz_t>self.val.n))
         return n
+
+    def __eq__(self, other):
+        if typecheck(other, fmpz_mod_ctx):
+            return fmpz_equal(self.val.n, (<fmpz_mod_ctx>other).val.n)
+        return False
+
+    def __hash__(self):
+        return hash(self.modulus())
 
     def __repr__(self):
         return "Context for fmpz_mod with modulus: {}".format(
@@ -151,7 +155,6 @@ cdef class fmpz_mod(flint_scalar):
                 return res
             else:
                 return not res
-        return NotImplemented
 
     def __bool__(self):
         return not self.is_zero()
@@ -284,7 +287,7 @@ cdef class fmpz_mod(flint_scalar):
         return fmpz_mod._div_(t, s)
 
     def __floordiv__(self, other):
-        raise NotImplemented
+        return NotImplemented
 
     def inverse(self, check=True):
         """

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -1,10 +1,38 @@
-from flint.flint_base.flint_base cimport flint_scalar
+from flint.flintlib.flint cimport slong
+from flint.flintlib.fmpz cimport (
+    fmpz_t,
+    COEFF_IS_MPZ,
+    fmpz_get_str
+)
 from flint.flintlib.fmpz_mod cimport (
+    fmpz_mod_ctx_t,
     fmpz_mod_ctx_init,
     fmpz_mod_ctx_set_modulus,
+    fmpz_mod_set_fmpz
+)
+from flint.utils.typecheck cimport typecheck
+from flint.utils.conversion cimport chars_from_str, str_from_chars, _str_trunc
+from flint.flint_base.flint_base cimport flint_scalar
+from flint.types.fmpz cimport (
+    fmpz,
+    any_as_fmpz,
 )
 
-from flint.types.fmpz cimport fmpz, any_as_fmpz
+cimport libc.stdlib
+
+# TODO: import this from types.fmpz somehow
+cdef fmpz_get_intlong(fmpz_t x):
+    """
+    Convert fmpz_t to a Python int or long.
+    """
+    cdef char * s
+    if COEFF_IS_MPZ(x[0]):
+        s = fmpz_get_str(NULL, 16, x)
+        v = int(str_from_chars(s), 16)
+        libc.stdlib.free(s)
+        return v
+    else:
+        return <slong>x[0]
 
 cdef class fmpz_mod_ctx:
     """
@@ -25,11 +53,14 @@ cdef class fmpz_mod_ctx:
         fmpz_mod_ctx_init(self.val, (<fmpz>mod).val)
 
     def __repr__(self):
-        # return "Context for fmpz_mod with modulus: %s" % self.ctx.n
-        return "Stuff: (%s, %s, %s)" % (self.val.n, self.val.mod, self.val.n_limbs)
+        return "Context for fmpz_mod with modulus: {}".format(
+            fmpz_get_intlong(self.val.n)
+        )
 
     def __str__(self):
-        return "fmpz_mod_ctx(%s)" % self.val.mod
+        return "fmpz_mod_ctx({})".format(
+            fmpz_get_intlong(self.val.n)
+        )
 
     def set_modulus(self, n):
         """
@@ -45,5 +76,20 @@ cdef class fmpz_mod_ctx:
 
         fmpz_mod_ctx_set_modulus(self.val, (<fmpz>mod).val)
 
+# This is buggy and broken
 cdef class fmpz_mod(flint_scalar):
-    pass
+    def __init__(self, val, ctx):
+        self.ctx = ctx
+
+        val = any_as_fmpz(val)
+        assert typecheck(val, fmpz)
+        fmpz_mod_set_fmpz(self.val, (<fmpz>val).val, (<fmpz_mod_ctx_t>self.ctx))
+
+    def repr(self):
+        return "fmpz_mod(%s, %s)" % (self.val, self.mod.n)
+
+    def str(self):
+        return str(fmpz_get_intlong(self.val))
+
+    def __int__(self):
+        return fmpz_get_intlong(self.val)

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -1,10 +1,7 @@
-from flint.flintlib.flint cimport slong
 from flint.flintlib.fmpz cimport (
     fmpz_t,
     fmpz_one,
     fmpz_set,
-    COEFF_IS_MPZ,
-    fmpz_get_str,
     fmpz_init,
     fmpz_clear,
     fmpz_equal
@@ -12,29 +9,13 @@ from flint.flintlib.fmpz cimport (
 from flint.flintlib.fmpz_mod cimport *
 
 from flint.utils.typecheck cimport typecheck
-from flint.utils.conversion cimport str_from_chars
 from flint.flint_base.flint_base cimport flint_scalar
 from flint.types.fmpz cimport (
     fmpz,
     any_as_fmpz,
+    fmpz_get_intlong
 )
 
-cimport libc.stdlib
-
-# TODO: import this from types.fmpz somehow, it's not good
-# to have the function repeated here.
-cdef fmpz_get_intlong(fmpz_t x):
-    """
-    Convert fmpz_t to a Python int or long.
-    """
-    cdef char * s
-    if COEFF_IS_MPZ(x[0]):
-        s = fmpz_get_str(NULL, 16, x)
-        v = int(str_from_chars(s), 16)
-        libc.stdlib.free(s)
-        return v
-    else:
-        return <slong>x[0]
 
 cdef class fmpz_mod_ctx:
     """

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -113,12 +113,13 @@ cdef class fmpz_mod(flint_scalar):
         # TODO: is this the best method for comparison?
         if typecheck(s, fmpz_mod) and typecheck(t, fmpz_mod):
             res = ((<fmpz_mod>s).val[0] == (<fmpz_mod>t).val[0]) and \
-                  ((<fmpz_mod>s).ctx.modulus() == (<fmpz_mod>t).ctx.modulus())
+                  ((<fmpz_mod>s).ctx.val.n == (<fmpz_mod>t).ctx.val.n)
             if op == 2:
                 return res
             else:
                 return not res
         # TODO: is this the best method for comparison?
+        # Seems like I'm doing too many type conversions?
         elif typecheck(s, fmpz_mod) and typecheck(t, int):
             res = int(s) == t % (<fmpz_mod>s).ctx.modulus()
             if op == 2:

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -5,14 +5,10 @@ from flint.flintlib.fmpz cimport (
     COEFF_IS_MPZ,
     fmpz_get_str
 )
-from flint.flintlib.fmpz_mod cimport (
-    fmpz_mod_ctx_t,
-    fmpz_mod_ctx_init,
-    fmpz_mod_ctx_set_modulus,
-    fmpz_mod_set_fmpz
-)
+from flint.flintlib.fmpz_mod cimport *
+
 from flint.utils.typecheck cimport typecheck
-from flint.utils.conversion cimport chars_from_str, str_from_chars, _str_trunc
+from flint.utils.conversion cimport str_from_chars
 from flint.flint_base.flint_base cimport flint_scalar
 from flint.types.fmpz cimport (
     fmpz,
@@ -21,7 +17,8 @@ from flint.types.fmpz cimport (
 
 cimport libc.stdlib
 
-# TODO: import this from types.fmpz somehow
+# TODO: import this from types.fmpz somehow, it's not good
+# to have the function repeated here.
 cdef fmpz_get_intlong(fmpz_t x):
     """
     Convert fmpz_t to a Python int or long.
@@ -38,13 +35,14 @@ cdef fmpz_get_intlong(fmpz_t x):
 cdef class fmpz_mod_ctx:
     """
     """
-    def __init__(self, n):
+    def __init__(self, mod):
         """
         """
         # Ensure modulus is fmpz type
-        mod = any_as_fmpz(n)
-        if mod is NotImplemented:
-            raise NotImplementedError("TODO")
+        if not typecheck(mod, fmpz):
+            mod = any_as_fmpz(mod)
+            if mod is NotImplemented:
+                raise NotImplementedError("TODO")
 
         # Ensure modulus is positive
         if mod < 1:
@@ -56,6 +54,7 @@ cdef class fmpz_mod_ctx:
     def modulus(self):
         """
         Return the modulus from the context as an fmpz
+        type
         """
         n = fmpz()
         fmpz_set(n.val, (<fmpz_t>self.val.n))
@@ -107,14 +106,112 @@ cdef class fmpz_mod(flint_scalar):
 
         fmpz_mod_set_fmpz(self.val, (<fmpz>val).val, (<fmpz_mod_ctx_t>self.ctx.val))
 
+    def is_zero(self):
+        return self == 0
+    
+    # TODO: kind of pointless, as we always ensure canonical on init?
+    def is_canonical(self):
+        cdef bint res
+        res = fmpz_mod_is_canonical(self.val, (<fmpz_mod_ctx_t>self.ctx.val))
+        return res == 1
+
+    def is_one(self):
+        cdef bint res
+        res = fmpz_mod_is_one(self.val, (<fmpz_mod_ctx_t>self.ctx.val))
+        return res == 1
+
+    def __richcmp__(s, t, int op):
+        cdef bint res
+        if op != 2 and op != 3:
+            raise TypeError("fmpz_mod cannot be ordered")
+        # TODO: is this the best method for comparison?
+        if typecheck(s, fmpz_mod) and typecheck(t, fmpz_mod):
+            res = ((<fmpz_mod>s).val[0] == (<fmpz_mod>t).val[0]) and \
+                  ((<fmpz_mod>s).ctx.modulus() == (<fmpz_mod>t).ctx.modulus())
+            if op == 2:
+                return res
+            else:
+                return not res
+        # TODO: is this the best method for comparison?
+        elif typecheck(s, fmpz_mod) and typecheck(t, int):
+            res = int(s) == t % (<fmpz_mod>s).ctx.modulus()
+            if op == 2:
+                return res
+            else:
+                return not res
+        return NotImplemented
+
+    def __bool__(self):
+        return not self.is_zero()
+
     def __repr__(self):
         return "fmpz_mod({}, {})".format(
             fmpz_get_intlong(self.val),
             self.ctx.modulus()
         )
 
-    def __str__(self):
-        return str(fmpz_get_intlong(self.val))
+    # TODO: seems ugly...
+    def __hash__(self):
+        return  hash(
+            (int(self), int(self.ctx.modulus()))
+        )
 
     def __int__(self):
         return fmpz_get_intlong(self.val)
+
+    def __str__(self):
+        return str(int(self))
+
+    # ---------------- #
+    #    Arithmetic    #
+    # ---------------- #
+
+    def __neg__(self):
+        res = fmpz()
+        fmpz_mod_neg(
+            res.val, self.val, 
+            (<fmpz_mod_ctx_t>self.ctx.val))
+        return self.ctx(res)
+
+    # TODO: proper type handing for the other...
+    def __add__(self, other):
+        res = fmpz()
+        fmpz_mod_add(
+            res.val, self.val, (<fmpz_mod>other).val, 
+            (<fmpz_mod_ctx_t>self.ctx.val)
+        )
+        return self.ctx(res)
+
+    def __radd__(self, other):
+        return other + self
+
+    def __iadd__(self, other):
+        fmpz_mod_add(
+            self.val, self.val, (<fmpz_mod>other).val, 
+            (<fmpz_mod_ctx_t>self.ctx.val)
+        )
+        return self
+
+    def __sub__(self, other):
+        pass
+
+    def __rsub__(self, other):
+        pass
+
+    def __isub__(self, other):
+        pass
+
+    def __mul__(self, other):
+        pass
+
+    def __rmul__(self, other):
+        pass
+
+    def __imul__(self, other):
+        pass
+
+    def __truediv__(self, other):
+        pass
+
+    def __floordiv__(self, other):
+        raise NotImplemented

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -125,7 +125,7 @@ cdef class fmpz_mod(flint_scalar):
                 raise NotImplementedError
         fmpz_mod_set_fmpz(self.val, (<fmpz>val).val, self.ctx.val)
 
-    def any_as_fmpz_mod(self, obj):
+    cdef any_as_fmpz_mod(self, obj):
         try:
             return self.ctx(obj)
         except NotImplementedError:

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -19,6 +19,11 @@ from flint.types.fmpz cimport (
 
 cdef class fmpz_mod_ctx:
     """
+    Context object for *fmpz_mod* initalised with a modulus `n`
+
+        >>> fmpz_mod_ctx(2**127 - 1)
+        fmpz_mod_ctx(170141183460469231731687303715884105727)
+
     """
     def __cinit__(self):
         # TODO: is this the best method?
@@ -47,6 +52,11 @@ cdef class fmpz_mod_ctx:
         """
         Return the modulus from the context as an fmpz
         type
+
+            >>> mod_ctx = fmpz_mod_ctx(2**127 - 1)
+            >>> mod_ctx.modulus()
+            170141183460469231731687303715884105727
+
         """
         n = fmpz()
         fmpz_set(n.val, (<fmpz_t>self.val.n))
@@ -70,6 +80,16 @@ cdef class fmpz_mod_ctx:
         return fmpz_mod(val, self)
 
 cdef class fmpz_mod(flint_scalar):
+    """
+    The *fmpz_mod* type represents integer modulo an 
+    arbitrary-size modulus. For wordsize modulus, see
+    *nmod*.
+
+        >>> fmpz_mod(-1, fmpz_mod_ctx(2**127 - 1))
+        fmpz_mod(170141183460469231731687303715884105726, 170141183460469231731687303715884105727)
+
+    """
+
     def __cinit__(self):
         fmpz_init(self.val)
 
@@ -105,9 +125,28 @@ cdef class fmpz_mod(flint_scalar):
             return NotImplemented
 
     def is_zero(self):
+        """
+        Return whether an element is equal to zero
+
+            >>> mod_ctx = fmpz_mod_ctx(163)
+            >>> mod_ctx(0).is_zero()
+            True
+            >>> mod_ctx(1).is_zero()
+            False
+        """
         return self == 0
     
     def is_one(self):
+        """
+        Return whether an element is equal to one
+
+            >>> mod_ctx = fmpz_mod_ctx(163)
+            >>> mod_ctx(0).is_one()
+            False
+            >>> mod_ctx(1).is_zero()
+            True
+        """
+
         cdef bint res
         res = fmpz_mod_is_one(self.val, self.ctx.val)
         return res == 1
@@ -267,6 +306,12 @@ cdef class fmpz_mod(flint_scalar):
 
         When check=False, the solutions is assumed to exist and Flint will abort on
         failure. 
+
+            >>> mod_ctx = fmpz_mod_ctx(163)
+            >>> mod_ctx(2).inverse()
+            fmpz_mod(82, 163)
+            >>> mod_ctx(2).inverse(check=False)
+            fmpz_mod(82, 163)
         """
         cdef fmpz_mod res
         res = fmpz_mod.__new__(fmpz_mod)

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -71,6 +71,16 @@ cdef class fmpz_mod_ctx:
             self.modulus()
         )
 
+    def __call__(self, val):
+        if not typecheck(val, fmpz):
+            val = any_as_fmpz(val)
+            if val is NotImplemented:
+                raise NotImplementedError("TODO")
+
+        return fmpz_mod(val, self)
+
+    # TODO: should this be allowed, or should
+    #       we make a ctx immutatble?
     def set_modulus(self, n):
         """
         """
@@ -85,14 +95,17 @@ cdef class fmpz_mod_ctx:
 
         fmpz_mod_ctx_set_modulus(self.val, (<fmpz>mod).val)
 
-# This is buggy and broken
+
 cdef class fmpz_mod(flint_scalar):
     def __init__(self, val, ctx):
         self.ctx = ctx
 
-        val_fmpz = any_as_fmpz(val)
-        assert typecheck(val_fmpz, fmpz)
-        fmpz_mod_set_fmpz(self.val, (<fmpz>val_fmpz).val, (<fmpz_mod_ctx_t>self.ctx.val))
+        if not typecheck(val, fmpz):
+            val = any_as_fmpz(val)
+            if val is NotImplemented:
+                raise NotImplementedError("TODO")
+
+        fmpz_mod_set_fmpz(self.val, (<fmpz>val).val, (<fmpz_mod_ctx_t>self.ctx.val))
 
     def __repr__(self):
         return "fmpz_mod({}, {})".format(

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -1,6 +1,7 @@
 from flint.flintlib.flint cimport slong
 from flint.flintlib.fmpz cimport (
     fmpz_t,
+    fmpz_set,
     COEFF_IS_MPZ,
     fmpz_get_str
 )
@@ -51,15 +52,23 @@ cdef class fmpz_mod_ctx:
 
         # Init the context
         fmpz_mod_ctx_init(self.val, (<fmpz>mod).val)
+    
+    def modulus(self):
+        """
+        Return the modulus from the context as an fmpz
+        """
+        n = fmpz()
+        fmpz_set(n.val, (<fmpz_t>self.val.n))
+        return n
 
     def __repr__(self):
         return "Context for fmpz_mod with modulus: {}".format(
-            fmpz_get_intlong(self.val.n)
+            self.modulus()
         )
 
     def __str__(self):
         return "fmpz_mod_ctx({})".format(
-            fmpz_get_intlong(self.val.n)
+            self.modulus()
         )
 
     def set_modulus(self, n):
@@ -81,14 +90,17 @@ cdef class fmpz_mod(flint_scalar):
     def __init__(self, val, ctx):
         self.ctx = ctx
 
-        val = any_as_fmpz(val)
-        assert typecheck(val, fmpz)
-        fmpz_mod_set_fmpz(self.val, (<fmpz>val).val, (<fmpz_mod_ctx_t>self.ctx))
+        val_fmpz = any_as_fmpz(val)
+        assert typecheck(val_fmpz, fmpz)
+        fmpz_mod_set_fmpz(self.val, (<fmpz>val_fmpz).val, (<fmpz_mod_ctx_t>self.ctx))
 
-    def repr(self):
-        return "fmpz_mod(%s, %s)" % (self.val, self.mod.n)
+    def __repr__(self):
+        return "fmpz_mod({}, {})".format(
+            fmpz_get_intlong(self.val),
+            self.ctx.modulus()
+        )
 
-    def str(self):
+    def __str__(self):
         return str(fmpz_get_intlong(self.val))
 
     def __int__(self):

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -92,7 +92,7 @@ cdef class fmpz_mod(flint_scalar):
 
         val_fmpz = any_as_fmpz(val)
         assert typecheck(val_fmpz, fmpz)
-        fmpz_mod_set_fmpz(self.val, (<fmpz>val_fmpz).val, (<fmpz_mod_ctx_t>self.ctx))
+        fmpz_mod_set_fmpz(self.val, (<fmpz>val_fmpz).val, (<fmpz_mod_ctx_t>self.ctx.val))
 
     def __repr__(self):
         return "fmpz_mod({}, {})".format(

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -18,9 +18,9 @@ from flint.types.fmpz cimport (
 
 
 cdef class fmpz_mod_ctx:
-    """
+    r"""
     Context object for creating :class:`~.fmpz_mod` initalised 
-    with a modulus `n`
+    with a modulus :math:`N`.
 
         >>> fmpz_mod_ctx(2**127 - 1)
         fmpz_mod_ctx(170141183460469231731687303715884105727)
@@ -308,8 +308,8 @@ cdef class fmpz_mod(flint_scalar):
         return NotImplemented
 
     def inverse(self, check=True):
-        """
-        Computes a^-1 mod N
+        r"""
+        Computes :math:`a^{-1} \pmod N`
 
         When check=False, the solutions is assumed to exist and Flint will abort on
         failure. 

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -20,9 +20,16 @@ from flint.types.fmpz cimport (
 cdef class fmpz_mod_ctx:
     """
     """
-    def __cinit__(self, mod):
-        """
-        """
+    def __cinit__(self):
+        # TODO: is this the best method?
+        cdef fmpz one = fmpz.__new__(fmpz)
+        fmpz_one(one.val)
+        fmpz_mod_ctx_init(self.val, one.val)
+
+    def __dealloc__(self):
+        fmpz_mod_ctx_clear(self.val)
+
+    def __init__(self, mod):
         # Ensure modulus is fmpz type
         if not typecheck(mod, fmpz):
             mod = any_as_fmpz(mod)
@@ -35,12 +42,6 @@ cdef class fmpz_mod_ctx:
 
         # Init the context
         fmpz_mod_ctx_init(self.val, (<fmpz>mod).val)
-
-    def __dealloc__(self):
-        fmpz_mod_ctx_clear(self.val)
-
-    def __init__(self, mod):
-        pass
     
     def modulus(self):
         """

--- a/src/flint/types/nmod.pyx
+++ b/src/flint/types/nmod.pyx
@@ -47,9 +47,6 @@ cdef class nmod(flint_scalar):
 
     """
 
-    # cdef mp_limb_t val
-    # cdef nmod_t mod
-
     def __init__(self, val, mod):
         cdef mp_limb_t m
         m = mod


### PR DESCRIPTION
This is a draft pull request adding the type `fmpz_mod`

Before continuing, I am a little confused about the `fmpz_mod_ctx` and it's behaving in a way which doesn't make much sense to me...

The context struct is of the form:

```cython
    ctypedef struct fmpz_mod_ctx_struct:
        fmpz_t n
        nmod_t mod
        ulong n_limbs[3]
        ulong ninv_limbs[3]
        fmpz_preinvn_struct * ninv_huge
    ctypedef fmpz_mod_ctx_struct fmpz_mod_ctx_t[1]
```

and as `n` is an `fmpz_t` type, I assumed this was the standard modulus. I think `mod` is then the modulus used for small input?

However, if I print out `ctx.n` and `ctx.mod` for various values I find:

```py
>>> from flint import *
>>> 
>>> fmpz_mod_ctx(100)
Stuff: ([100], {'n': 100, 'ninv': 5165088340638674452, 'norm': 57}, [0, 0, 0])
>>> fmpz_mod_ctx(10**10)
Stuff: ([10000000000], {'n': 10000000000, 'ninv': 13244520931996183421, 'norm': 30}, [0, 0, 0])
>>> fmpz_mod_ctx(10**100)
Stuff: ([4611721077084439544], {'n': 0, 'ninv': 0, 'norm': 0}, [0, 0, 0])
```

Is it obvious here what I'm doing wrong?? Looking at the data out (a list, a dict, and a list) it seems I don't understand the "python" version of the types in this struct at all :/