### PR TITLE
Added fmpq_set_any_ref

### DIFF
--- a/src/flint/types/fmpq.pxd
+++ b/src/flint/types/fmpq.pxd
@@ -1,9 +1,7 @@
 from flint.flint_base.flint_base cimport flint_scalar
-
 from flint.flintlib.fmpq cimport fmpq_t
 
+cdef int fmpq_set_any_ref(fmpq_t x, obj)
 cdef any_as_fmpq(obj)
 cdef class fmpq(flint_scalar):
     cdef fmpq_t val
-
-


### PR DESCRIPTION
For implementing `fmpq_mpoly` a `fmpq_set_any_ref` function would be convenient and useful.  Also it makes `fmpq` work similiarly to `fmpz`, `arb`, and `acb`.

There is some ugliness (I inject a c typedef into the code) to get around the fact that what flint calls a `fmpq`, python flint calls a `fmpq_struct`.