### PR TITLE
Check for zero in deflation to avoid segfault

### DIFF
--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -437,6 +437,7 @@ def test_fmpz_poly():
     assert Z([1,2,1]).sqrt() == Z([1,1])
     assert Z([1,2,2]).sqrt() is None
     assert Z([1,0,2,0,3]).deflation() == (Z([1,2,3]), 2)
+    assert Z([]).deflation() == (Z([]), 1)
     assert Z([1,1]).deflation() == (Z([1,1]), 1)
     [(r,m)] = Z([1,1]).complex_roots()
     assert m == 1

--- a/src/flint/types/fmpz_poly.pyx
+++ b/src/flint/types/fmpz_poly.pyx
@@ -513,6 +513,8 @@ cdef class fmpz_poly(flint_poly):
     def deflation(self):
         cdef fmpz_poly v
         cdef ulong n
+        if fmpz_poly_is_zero(self.val):
+            return self, 1
         n = arb_fmpz_poly_deflation(self.val)
         if n == 1:
             return self, int(n)


### PR DESCRIPTION
Currently:
```python
In [1]: import flint

In [2]: p = flint.fmpz_poly([])

In [3]: p
Out[3]: 0

In [4]: p.deflation()
Exception (fmpz_poly_deflate). Division by zero.
Aborted (core dumped)
```
With the change here we instead have:
```python
In [4]: p.deflation()
Out[4]: (0, 1)
```