### PR TITLE
fix(fmpz_mod): avoid using malloc/free

### DIFF
--- a/src/flint/types/fmpz_mod.pxd
+++ b/src/flint/types/fmpz_mod.pxd
@@ -8,12 +8,14 @@ from flint.flintlib.fmpz_mod cimport (
 cdef class fmpz_mod_ctx:
     cdef fmpz_mod_ctx_t val
     cdef bint _is_prime
-    cdef fmpz_mod_discrete_log_pohlig_hellman_t *L
+    cdef bint _init_L
+    cdef fmpz_mod_discrete_log_pohlig_hellman_t L
+
     cdef set_any_as_fmpz_mod(self, fmpz_t val, obj)
     cdef any_as_fmpz_mod(self, obj)
-    cdef _precompute_dlog_prime(self)
+    cdef discrete_log_pohlig_hellman_run(self, fmpz_t x, fmpz_t y)
     
 cdef class fmpz_mod(flint_scalar):
     cdef fmpz_mod_ctx ctx
     cdef fmpz_t val
-    cdef fmpz_t *x_g
+    cdef fmpz_t x_g


### PR DESCRIPTION
Fixes the Windows crash seen at https://github.com/flintlib/python-flint/pull/84#issuecomment-1762411823