### PR TITLE
Update cibuildwheel version in Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ cirrus_wheels_macos_arm64_task:
     - which python
     - python --version
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.11.4
+    - python -m pip install cibuildwheel==2.16.2
   run_cibuildwheel_script:
     - bin/cibw.sh
   wheels_artifacts:


### PR DESCRIPTION
Follow up to https://github.com/flintlib/python-flint/pull/100#issuecomment-1773939478

The cibuildwheel version for Cirrus CI needs to be updated so that it can build wheels for Python 3.12.