### PR TITLE
Add fmpz_mod_mat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ MANIFEST
 *.swp
 .python-version
 *.DS_Store
+.venv

--- a/doc/source/fmpz_mod_mat.rst
+++ b/doc/source/fmpz_mod_mat.rst
@@ -1,0 +1,8 @@
+**fmpz_mod_mat** -- matrices over integers mod n for arbitrary n
+===============================================================================
+
+.. autoclass :: flint.fmpz_mod_mat
+  :members:
+  :inherited-members:
+  :undoc-members:
+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,6 +58,7 @@ Matrix types
    fmpz_mat.rst
    fmpq_mat.rst
    nmod_mat.rst
+   fmpz_mod_mat.rst
    arb_mat.rst
    acb_mat.rst
 

--- a/setup.py
+++ b/setup.py
@@ -76,18 +76,30 @@ packages=[
 
 ext_files = [
     ("flint.pyflint", ["src/flint/pyflint.pyx"]),
+
+    ("flint.flint_base.flint_base", ["src/flint/flint_base/flint_base.pyx"]),
+    ("flint.flint_base.flint_context", ["src/flint/flint_base/flint_context.pyx"]),
+
     ("flint.types.fmpz", ["src/flint/types/fmpz.pyx"]),
     ("flint.types.fmpz_poly", ["src/flint/types/fmpz_poly.pyx"]),
+    ("flint.types.fmpz_mpoly", ["src/flint/types/fmpz_mpoly.pyx"]),
     ("flint.types.fmpz_mat", ["src/flint/types/fmpz_mat.pyx"]),
     ("flint.types.fmpz_series", ["src/flint/types/fmpz_series.pyx"]),
+
     ("flint.types.fmpq", ["src/flint/types/fmpq.pyx"]),
     ("flint.types.fmpq_poly", ["src/flint/types/fmpq_poly.pyx"]),
     ("flint.types.fmpq_mat", ["src/flint/types/fmpq_mat.pyx"]),
     ("flint.types.fmpq_series", ["src/flint/types/fmpq_series.pyx"]),
+
     ("flint.types.nmod", ["src/flint/types/nmod.pyx"]),
     ("flint.types.nmod_poly", ["src/flint/types/nmod_poly.pyx"]),
     ("flint.types.nmod_mat", ["src/flint/types/nmod_mat.pyx"]),
     ("flint.types.nmod_series", ["src/flint/types/nmod_series.pyx"]),
+
+    ("flint.types.fmpz_mod", ["src/flint/types/fmpz_mod.pyx"]),
+    ("flint.types.fmpz_mod_poly", ["src/flint/types/fmpz_mod_poly.pyx"]),
+    ("flint.types.fmpz_mod_mat", ["src/flint/types/fmpz_mod_mat.pyx"]),
+
     ("flint.types.arf", ["src/flint/types/arf.pyx"]),
     ("flint.types.arb", ["src/flint/types/arb.pyx"]),
     ("flint.types.arb_poly", ["src/flint/types/arb_poly.pyx"]),
@@ -97,15 +109,10 @@ ext_files = [
     ("flint.types.acb_poly", ["src/flint/types/acb_poly.pyx"]),
     ("flint.types.acb_mat", ["src/flint/types/acb_mat.pyx"]),
     ("flint.types.acb_series", ["src/flint/types/acb_series.pyx"]),
-    ("flint.types.fmpz_mpoly", ["src/flint/types/fmpz_mpoly.pyx"]),
-    ("flint.types.fmpz_mod", ["src/flint/types/fmpz_mod.pyx"]),
-    ("flint.types.fmpz_mod_poly", ["src/flint/types/fmpz_mod_poly.pyx"]),
-    ("flint.types.dirichlet", ["src/flint/types/dirichlet.pyx"]),
-    ("flint.flint_base.flint_base", ["src/flint/flint_base/flint_base.pyx"]),
-    ("flint.flint_base.flint_context", ["src/flint/flint_base/flint_context.pyx"]),
-    # Helper for unittests
-    ("flint.functions.showgood", ["src/flint/functions/showgood.pyx"]),
 
+    ("flint.types.dirichlet", ["src/flint/types/dirichlet.pyx"]),
+
+    ("flint.functions.showgood", ["src/flint/functions/showgood.pyx"]),
 ]
 
 ext_options = {

--- a/src/flint/__init__.py
+++ b/src/flint/__init__.py
@@ -1,16 +1,25 @@
 from .pyflint import *
+
 from .types.fmpz import *
 from .types.fmpz_poly import *
 from .types.fmpz_mat import *
 from .types.fmpz_series import *
+
 from .types.fmpq import *
 from .types.fmpq_poly import *
 from .types.fmpq_mat import *
 from .types.fmpq_series import *
+
 from .types.nmod import *
 from .types.nmod_poly import *
 from .types.nmod_mat import *
 from .types.nmod_series import *
+
+from .types.fmpz_mpoly import *
+from .types.fmpz_mod import *
+from .types.fmpz_mod_poly import *
+from .types.fmpz_mod_mat import fmpz_mod_mat
+
 from .types.arf import *
 from .types.arb import *
 from .types.arb_poly import *
@@ -20,9 +29,7 @@ from .types.acb import *
 from .types.acb_poly import *
 from .types.acb_mat import *
 from .types.acb_series import *
-from .types.fmpz_mpoly import *
-from .types.fmpz_mod import *
-from .types.fmpz_mod_poly import *
+
 from .types.dirichlet import *
 from .functions.showgood import good, showgood
 

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -1,4 +1,6 @@
+from flint.flintlib.flint cimport FLINT_BITS as _FLINT_BITS
 from flint.flint_base.flint_context cimport thectx
+
 
 cdef class flint_elem:
     def __repr__(self):

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -136,8 +136,6 @@ cdef class flint_mat(flint_elem):
     """
 
     def repr(self):
-        if thectx.pretty:
-            return str(self)
         # XXX
         return "%s(%i, %i, [%s])" % (type(self).__name__,
             self.nrows(), self.ncols(), (", ".join(map(str, self.entries()))))

--- a/src/flint/flintlib/fmpz_mod_mat.pxd
+++ b/src/flint/flintlib/fmpz_mod_mat.pxd
@@ -1,0 +1,75 @@
+from flint.flintlib.flint cimport ulong, slong, fmpz_struct, flint_rand_t
+from flint.flintlib.fmpz cimport fmpz_t
+from flint.flintlib.fmpz_mod cimport fmpz_mod_ctx_t
+from flint.flintlib.fmpz_mat cimport fmpz_mat_t
+from flint.flintlib.fmpz_mod_poly cimport fmpz_mod_poly_t
+
+
+cdef extern from "flint/fmpz_mod_mat.h":
+    ctypedef struct fmpz_mod_mat_struct:
+        fmpz_mat_t mat
+        fmpz_t mod
+    ctypedef fmpz_mod_mat_struct fmpz_mod_mat_t[1]
+
+
+cdef extern from "flint/fmpz_mod_mat.h":
+    # This is not exposed in the docs:
+    int fmpz_mod_mat_equal(const fmpz_mod_mat_t mat1, const fmpz_mod_mat_t mat2);
+
+
+cdef extern from "flint/fmpz_mod_mat.h":
+    fmpz_struct * fmpz_mod_mat_entry(const fmpz_mod_mat_t mat, slong i, slong j)
+    void fmpz_mod_mat_set_entry(fmpz_mod_mat_t mat, slong i, slong j, const fmpz_t val)
+    void fmpz_mod_mat_init(fmpz_mod_mat_t mat, slong rows, slong cols, const fmpz_t n)
+    void fmpz_mod_mat_init_set(fmpz_mod_mat_t mat, const fmpz_mod_mat_t src)
+    void fmpz_mod_mat_clear(fmpz_mod_mat_t mat)
+    slong fmpz_mod_mat_nrows(const fmpz_mod_mat_t mat)
+    slong fmpz_mod_mat_ncols(const fmpz_mod_mat_t mat)
+    void _fmpz_mod_mat_set_mod(fmpz_mod_mat_t mat, const fmpz_t n)
+    void fmpz_mod_mat_one(fmpz_mod_mat_t mat)
+    void fmpz_mod_mat_zero(fmpz_mod_mat_t mat)
+    void fmpz_mod_mat_swap(fmpz_mod_mat_t mat1, fmpz_mod_mat_t mat2)
+    void fmpz_mod_mat_swap_entrywise(fmpz_mod_mat_t mat1, fmpz_mod_mat_t mat2)
+    int fmpz_mod_mat_is_empty(const fmpz_mod_mat_t mat)
+    int fmpz_mod_mat_is_square(const fmpz_mod_mat_t mat)
+    void _fmpz_mod_mat_reduce(fmpz_mod_mat_t mat)
+    void fmpz_mod_mat_randtest(fmpz_mod_mat_t mat, flint_rand_t state)
+    void fmpz_mod_mat_window_init(fmpz_mod_mat_t window, const fmpz_mod_mat_t mat, slong r1, slong c1, slong r2, slong c2)
+    void fmpz_mod_mat_window_clear(fmpz_mod_mat_t window)
+    void fmpz_mod_mat_concat_horizontal(fmpz_mod_mat_t res, const fmpz_mod_mat_t mat1, const fmpz_mod_mat_t mat2)
+    void fmpz_mod_mat_concat_vertical(fmpz_mod_mat_t res, const fmpz_mod_mat_t mat1, const fmpz_mod_mat_t mat2)
+    void fmpz_mod_mat_print_pretty(const fmpz_mod_mat_t mat)
+    int fmpz_mod_mat_is_zero(const fmpz_mod_mat_t mat)
+    void fmpz_mod_mat_set(fmpz_mod_mat_t B, const fmpz_mod_mat_t A)
+    void fmpz_mod_mat_transpose(fmpz_mod_mat_t B, const fmpz_mod_mat_t A)
+    void fmpz_mod_mat_set_fmpz_mat(fmpz_mod_mat_t A, const fmpz_mat_t B)
+    void fmpz_mod_mat_get_fmpz_mat(fmpz_mat_t A, const fmpz_mod_mat_t B)
+    void fmpz_mod_mat_add(fmpz_mod_mat_t C, const fmpz_mod_mat_t A, const fmpz_mod_mat_t B)
+    void fmpz_mod_mat_sub(fmpz_mod_mat_t C, const fmpz_mod_mat_t A, const fmpz_mod_mat_t B)
+    void fmpz_mod_mat_neg(fmpz_mod_mat_t B, const fmpz_mod_mat_t A)
+    void fmpz_mod_mat_scalar_mul_si(fmpz_mod_mat_t B, const fmpz_mod_mat_t A, slong c)
+    void fmpz_mod_mat_scalar_mul_ui(fmpz_mod_mat_t B, const fmpz_mod_mat_t A, ulong c)
+    void fmpz_mod_mat_scalar_mul_fmpz(fmpz_mod_mat_t B, const fmpz_mod_mat_t A, fmpz_t c)
+    void fmpz_mod_mat_mul(fmpz_mod_mat_t C, const fmpz_mod_mat_t A, const fmpz_mod_mat_t B)
+    # unimported types  {'thread_pool_handle'}
+    # void _fmpz_mod_mat_mul_classical_threaded_pool_op(fmpz_mod_mat_t D, const fmpz_mod_mat_t C, const fmpz_mod_mat_t A, const fmpz_mod_mat_t B, int op, thread_pool_handle * threads, slong num_threads)
+    void _fmpz_mod_mat_mul_classical_threaded_op(fmpz_mod_mat_t D, const fmpz_mod_mat_t C, const fmpz_mod_mat_t A, const fmpz_mod_mat_t B, int op)
+    void fmpz_mod_mat_mul_classical_threaded(fmpz_mod_mat_t C, const fmpz_mod_mat_t A, const fmpz_mod_mat_t B)
+    void fmpz_mod_mat_sqr(fmpz_mod_mat_t B, const fmpz_mod_mat_t A)
+    void fmpz_mod_mat_mul_fmpz_vec(fmpz_struct * c, const fmpz_mod_mat_t A, const fmpz_struct * b, slong blen)
+    void fmpz_mod_mat_mul_fmpz_vec_ptr(fmpz_struct * const * c, const fmpz_mod_mat_t A, const fmpz_struct * const * b, slong blen)
+    void fmpz_mod_mat_fmpz_vec_mul(fmpz_struct * c, const fmpz_struct * a, slong alen, const fmpz_mod_mat_t B)
+    void fmpz_mod_mat_fmpz_vec_mul_ptr(fmpz_struct * const * c, const fmpz_struct * const * a, slong alen, const fmpz_mod_mat_t B)
+    void fmpz_mod_mat_trace(fmpz_t trace, const fmpz_mod_mat_t mat)
+    slong fmpz_mod_mat_rref(slong * perm, fmpz_mod_mat_t mat)
+    void fmpz_mod_mat_strong_echelon_form(fmpz_mod_mat_t mat)
+    slong fmpz_mod_mat_howell_form(fmpz_mod_mat_t mat)
+    int fmpz_mod_mat_inv(fmpz_mod_mat_t B, fmpz_mod_mat_t A)
+    slong fmpz_mod_mat_lu(slong * P, fmpz_mod_mat_t A, int rank_check)
+    void fmpz_mod_mat_solve_tril(fmpz_mod_mat_t X, const fmpz_mod_mat_t L, const fmpz_mod_mat_t B, int unit)
+    void fmpz_mod_mat_solve_triu(fmpz_mod_mat_t X, const fmpz_mod_mat_t U, const fmpz_mod_mat_t B, int unit)
+    int fmpz_mod_mat_solve(fmpz_mod_mat_t X, const fmpz_mod_mat_t A, const fmpz_mod_mat_t B)
+    int fmpz_mod_mat_can_solve(fmpz_mod_mat_t X, const fmpz_mod_mat_t A, const fmpz_mod_mat_t B)
+    void fmpz_mod_mat_similarity(fmpz_mod_mat_t M, slong r, fmpz_t d)
+    void fmpz_mod_mat_charpoly(fmpz_mod_poly_t p, const fmpz_mod_mat_t M, const fmpz_mod_ctx_t ctx)
+    void fmpz_mod_mat_minpoly(fmpz_mod_poly_t p, const fmpz_mod_mat_t M, const fmpz_mod_ctx_t ctx)

--- a/src/flint/test/__main__.py
+++ b/src/flint/test/__main__.py
@@ -60,6 +60,7 @@ def run_doctests(verbose=None):
                flint.types.fmpz_series,
                flint.types.fmpz_mod,
                flint.types.fmpz_mod_poly,
+               flint.types.fmpz_mod_mat,
                flint.types.fmpq,
                flint.types.fmpq_poly,
                flint.types.fmpq_mat,

--- a/src/flint/test/test.py
+++ b/src/flint/test/test.py
@@ -557,7 +557,7 @@ def test_fmpz_mat():
     assert raises(lambda: M([[1],[2,3]]), ValueError)
     assert raises(lambda: M(None), TypeError)
     assert raises(lambda: M(2,2,[1,2,3]), ValueError)
-    assert raises(lambda: M(2,2,2,2), ValueError)
+    assert raises(lambda: M(2,2,2,2), TypeError)
     assert M([[1,2,3],[4,5,6]]) == M(2,3,[1,2,3,4,5,6])
     assert raises(lambda: M([[1]]) < M([[2]]), TypeError)
     assert (M([[1]]) == 1) is False
@@ -571,15 +571,15 @@ def test_fmpz_mat():
     def set_bad(i,j):
         D[i,j] = -1
     # XXX: Should be IndexError
-    raises(lambda: set_bad(2,0), ValueError)
-    raises(lambda: set_bad(0,2), ValueError)
-    raises(lambda: D[0,2], ValueError)
-    raises(lambda: D[0,2], ValueError)
+    raises(lambda: set_bad(2,0), IndexError)
+    raises(lambda: set_bad(0,2), IndexError)
+    raises(lambda: D[0,2], IndexError)
+    raises(lambda: D[0,2], IndexError)
     # XXX: Negative indices?
-    raises(lambda: set_bad(-1,0), ValueError)
-    raises(lambda: set_bad(0,-1), ValueError)
-    raises(lambda: D[-1,0], ValueError)
-    raises(lambda: D[0,-1], ValueError)
+    raises(lambda: set_bad(-1,0), IndexError)
+    raises(lambda: set_bad(0,-1), IndexError)
+    raises(lambda: D[-1,0], IndexError)
+    raises(lambda: D[0,-1], IndexError)
     assert M.hadamard(2) == M([[1,1],[1,-1]])
     assert raises(lambda: M.hadamard(3), ValueError)
     assert M.hadamard(2).is_hadamard() is True
@@ -1067,7 +1067,7 @@ def test_fmpq_mat():
     assert raises(lambda: Q(2,3,[1,2,3,4,5]), ValueError)
     assert raises(lambda: Q([[1,2,3],[4,[],6]]), TypeError)
     assert raises(lambda: Q(2,3,[1,2,3,4,[],6]), TypeError)
-    assert raises(lambda: Q(2,3,[1,2],[3,4]), ValueError)
+    assert raises(lambda: Q(2,3,[1,2],[3,4]), TypeError)
     assert bool(Q([[1]])) is True
     assert bool(Q([[0]])) is False
     assert raises(lambda: Q([[1]]) < Q([[0]]), TypeError)
@@ -1078,13 +1078,12 @@ def test_fmpq_mat():
     # XXX: Negative indices should probably be allowed
     def set_bad(i):
         M[i,0] = -1
-    raises(lambda: M[-1,0], ValueError)
-    raises(lambda: M[0,-1], ValueError)
-    raises(lambda: set_bad(-1), ValueError)
-    # XXX: Should be IndexError
-    raises(lambda: M[2,0], ValueError)
-    raises(lambda: M[0,2], ValueError)
-    raises(lambda: set_bad(2), ValueError)
+    raises(lambda: M[-1,0], IndexError)
+    raises(lambda: M[0,-1], IndexError)
+    raises(lambda: set_bad(-1), IndexError)
+    raises(lambda: M[2,0], IndexError)
+    raises(lambda: M[0,2], IndexError)
+    raises(lambda: set_bad(2), IndexError)
     assert Q([[1,2,3],[4,5,6]]).transpose() == Q([[1,4],[2,5],[3,6]])
     raises(lambda: M + [], TypeError)
     raises(lambda: M - [], TypeError)
@@ -1488,9 +1487,12 @@ def test_nmod_mat():
     assert A*(B*C) == (A*B)*C
     assert bool(M(2,2,[0,0,0,0],17)) == False
     assert bool(M(2,2,[0,0,0,1],17)) == True
-    ctx.pretty = False
-    assert repr(M(2,2,[1,2,3,4],17)) == 'nmod_mat(2, 2, [1, 2, 3, 4], 17)'
-    ctx.pretty = True
+    pretty = ctx.pretty
+    try:
+        ctx.pretty = False
+        assert repr(M(2,2,[1,2,3,4],17)) == 'nmod_mat(2, 2, [1, 2, 3, 4], 17)'
+    finally:
+        ctx.pretty = pretty
     assert str(M(2,2,[1,2,3,4],17)) == '[1, 2]\n[3, 4]'
     assert repr(M(2,2,[1,2,3,4],17)) == '[1, 2]\n[3, 4]'
     assert M(1,2,[3,4],17) / 3 == M(1,2,[3,4],17) * (~G(3,17))
@@ -1504,7 +1506,7 @@ def test_nmod_mat():
     assert raises(lambda: M(None,17), TypeError)
     assert M(2,3,17) == M(2,3,[0,0,0,0,0,0],17)
     assert raises(lambda: M(2,3,[0,0,0,0,0],17), ValueError)
-    assert raises(lambda: M(2,3,[0,1],[1,2],17), ValueError)
+    assert raises(lambda: M(2,3,[0,1],[1,2],17), TypeError)
     assert M([[1,2,3],[4,5,6]], 5) == M(2,3,[1,2,3,4,5,6], 5)
     assert raises(lambda: M([[0]],13) < M([[1]],13), TypeError)
     assert (M([[1]],17) == M([[1]],13)) is False
@@ -1522,18 +1524,17 @@ def test_nmod_mat():
     def set_bad(i,j):
         M3[i,j] = 2
     # XXX: negative indices should be allowed
-    assert raises(lambda: M3[-1,0], ValueError)
-    assert raises(lambda: M3[0,-1], ValueError)
-    assert raises(lambda: set_bad(-1,0), ValueError)
-    assert raises(lambda: set_bad(0,-1), ValueError)
-    # XXX: Should be IndexError
-    assert raises(lambda: M3[2,0], ValueError)
-    assert raises(lambda: M3[0,2], ValueError)
-    assert raises(lambda: set_bad(2,0), ValueError)
-    assert raises(lambda: set_bad(0,2), ValueError)
+    assert raises(lambda: M3[-1,0], IndexError)
+    assert raises(lambda: M3[0,-1], IndexError)
+    assert raises(lambda: set_bad(-1,0), IndexError)
+    assert raises(lambda: set_bad(0,-1), IndexError)
+    assert raises(lambda: M3[2,0], IndexError)
+    assert raises(lambda: M3[0,2], IndexError)
+    assert raises(lambda: set_bad(2,0), IndexError)
+    assert raises(lambda: set_bad(0,2), IndexError)
     def set_bad2():
         M3[0,0] = 1.5
-    assert raises(set_bad2, ValueError)
+    assert raises(set_bad2, TypeError)
     assert raises(lambda: M3 + [], TypeError)
     assert raises(lambda: M3 - [], TypeError)
     assert raises(lambda: M3 * [], TypeError)
@@ -2643,8 +2644,7 @@ def test_matrices_eq():
 
 def test_matrices_constructor():
     for M, S, is_field in _all_matrices():
-        # XXX: Inconsistent exception types for different matrix types.
-        assert raises(lambda: M(), (ValueError, TypeError))
+        assert raises(lambda: M(), TypeError)
 
         # Empty matrices
         assert M([]).nrows() == 0
@@ -2720,13 +2720,8 @@ def test_matrices_strrepr():
         A_str = "[1, 2]\n[3, 4]"
         A_repr = _matrix_repr(A)
 
-        # XXX: inconsistent repr/str for different matrix types
-        if type(A) is not flint.nmod_mat:
-            assert A.str() == A_str, type(A).__name__
-            if type(A) not in (flint.fmpz_mat, flint.fmpq_mat):
-                assert A.repr() == A_repr, type(A).__name__
-            else:
-                assert A.repr() == A_str, type(A).__name__
+        assert A.str() == A_str, type(A).__name__
+        assert A.repr() == A_repr, type(A).__name__
 
         # str always returns a pretty result
         assert str(A) == A_str, type(A).__name__
@@ -2749,14 +2744,13 @@ def test_matrices_getitem():
         assert M1234[0, 1] == S(2)
         assert M1234[1, 0] == S(3)
         assert M1234[1, 1] == S(4)
-        # XXX: Should be IndexError
-        assert raises(lambda: M1234[0, 2], ValueError)
-        assert raises(lambda: M1234[2, 0], ValueError)
-        assert raises(lambda: M1234[2, 2], ValueError)
+        assert raises(lambda: M1234[0, 2], IndexError)
+        assert raises(lambda: M1234[2, 0], IndexError)
+        assert raises(lambda: M1234[2, 2], IndexError)
         # XXX: Should negative indices be allowed?
-        assert raises(lambda: M1234[-1, 0], ValueError)
-        assert raises(lambda: M1234[0, -1], ValueError)
-        assert raises(lambda: M1234[-1, -1], ValueError)
+        assert raises(lambda: M1234[-1, 0], IndexError)
+        assert raises(lambda: M1234[0, -1], IndexError)
+        assert raises(lambda: M1234[-1, -1], IndexError)
 
 
 def test_matrices_setitem():
@@ -2770,19 +2764,19 @@ def test_matrices_setitem():
 
         def setbad(obj, key, val):
             obj[key] = val
-        # XXX: Inconsistent exception types for different matrix types.
-        assert raises(lambda: setbad(M1234, (0,0), None), (TypeError, ValueError))
+
+        assert raises(lambda: setbad(M1234, (0,0), None), TypeError)
         assert raises(lambda: setbad(M1234, (0,None), 1), TypeError)
         assert raises(lambda: setbad(M1234, (None,0), 1), TypeError)
         assert raises(lambda: setbad(M1234, None, 1), TypeError)
-        # XXX: Should be IndexError
-        assert raises(lambda: setbad(M1234, (0,2), 1), ValueError)
-        assert raises(lambda: setbad(M1234, (2,0), 1), ValueError)
-        assert raises(lambda: setbad(M1234, (2,2), 1), ValueError)
+
+        assert raises(lambda: setbad(M1234, (0,2), 1), IndexError)
+        assert raises(lambda: setbad(M1234, (2,0), 1), IndexError)
+        assert raises(lambda: setbad(M1234, (2,2), 1), IndexError)
         # XXX: Should negative indices be allowed?
-        assert raises(lambda: setbad(M1234, (-1,0), 1), ValueError)
-        assert raises(lambda: setbad(M1234, (0,-1), 1), ValueError)
-        assert raises(lambda: setbad(M1234, (-1,-1), 1), ValueError)
+        assert raises(lambda: setbad(M1234, (-1,0), 1), IndexError)
+        assert raises(lambda: setbad(M1234, (0,-1), 1), IndexError)
+        assert raises(lambda: setbad(M1234, (-1,-1), 1), IndexError)
 
 
 def test_matrices_bool():
@@ -2819,7 +2813,6 @@ def test_matrices_add():
             assert raises(lambda: M1234 + M2([[1, 2, 3], [4, 5, 6]]), ValueError)
             assert raises(lambda: M2([[1, 2, 3], [4, 5, 6]]) + M1234, ValueError)
         for M2 in _incompatible_matrix_types(M):
-            # XXX: Inconsistent exception types for different matrix types.
             assert raises(lambda: M1234 + M2([[1, 2], [3, 4]]), (TypeError, ValueError))
             assert raises(lambda: M2([[1, 2], [3, 4]]) + M1234, (TypeError, ValueError))
 
@@ -2840,7 +2833,6 @@ def test_matrices_sub():
             assert raises(lambda: M1234 - M2([[1, 2, 3], [4, 5, 6]]), ValueError)
             assert raises(lambda: M2([[1, 2, 3], [4, 5, 6]]) - M1234, ValueError)
         for M2 in _incompatible_matrix_types(M):
-            # XXX: Inconsistent exception types for different matrix types.
             assert raises(lambda: M1234 - M2([[1, 2], [3, 4]]), (TypeError, ValueError))
             assert raises(lambda: M2([[1, 2], [3, 4]]) - M1234, (TypeError, ValueError))
 
@@ -2867,7 +2859,6 @@ def test_matrices_mul():
             assert M2([[1, 2], [3, 4]]) * M1234 == M([[7, 10], [15, 22]])
 
         for M2 in _incompatible_matrix_types(M):
-            # XXX: Inconsistent exception types for different matrix types.
             assert raises(lambda: M1234 * M2([[1, 2], [3, 4]]), (TypeError, ValueError))
             assert raises(lambda: M2([[1, 2], [3, 4]]) * M1234, (TypeError, ValueError))
 
@@ -2875,9 +2866,6 @@ def test_matrices_mul():
 def test_matrices_pow():
     for M, S, is_field in _all_matrices():
         M1234 = M([[1, 2], [3, 4]])
-        # XXX: nmod_mat should support __pow__
-        if type(M1234) is flint.nmod_mat:
-            continue
         assert M1234**0 == M([[1, 0], [0, 1]])
         assert M1234**1 == M1234
         assert M1234**2 == M([[7, 10], [15, 22]])
@@ -2889,15 +2877,9 @@ def test_matrices_pow():
             Ms = M([[1, 2], [3, 6]])
             assert raises(lambda: Ms**-1, ZeroDivisionError)
         Mr = M([[1, 2, 3], [4, 5, 6]])
-        # XXX: Fix fmpq_mat.__pow__
-        if type(Mr) is flint.fmpq_mat:
-            assert raises(lambda: Mr**0, AssertionError)
-            assert Mr ** 1 == Mr
-            assert raises(lambda: Mr**2, ValueError)
-        else:
-            assert raises(lambda: Mr**0, ValueError)
-            assert raises(lambda: Mr**1, ValueError)
-            assert raises(lambda: Mr**2, ValueError)
+        assert raises(lambda: Mr**0, ValueError)
+        assert raises(lambda: Mr**1, ValueError)
+        assert raises(lambda: Mr**2, ValueError)
         assert raises(lambda: M1234**None, TypeError)
         assert raises(lambda: None**M1234, TypeError)
 
@@ -2938,41 +2920,28 @@ def test_matrices_det():
 
 def test_matrices_charpoly():
     for M, S, is_field in _all_matrices():
-        # XXX: Add support for nmod_mat charpoly
-        if type(M([[0]])) is flint.nmod_mat:
-            continue
         P = _poly_type_from_matrix_type(M)
         M1234 = M([[1, 2], [3, 4]])
         assert M1234.charpoly() == P([-2, -5, 1])
         M9 = M([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
         assert M9.charpoly() == P([3, -12, -16, 1])
         Mr = M([[1, 2, 3], [4, 5, 6]])
-        # XXX: Fix fmpz_mat and fmpq_mat charpoly to not abort
-        if M is not flint.fmpz_mat and M is not flint.fmpq_mat:
-            assert raises(lambda: Mr.charpoly(), ValueError)
+        assert raises(lambda: Mr.charpoly(), ValueError)
 
 
 def test_matrices_minpoly():
     for M, S, is_field in _all_matrices():
-        # XXX: Add support for nmod_mat minpoly
-        if type(M([[0]])) is flint.nmod_mat:
-            continue
         P = _poly_type_from_matrix_type(M)
         M1234 = M([[1, 2], [3, 4]])
         assert M1234.minpoly() == P([-2, -5, 1])
         M9 = M([[2, 1, 0], [0, 2, 0], [0, 0, 2]])
         assert M9.minpoly() == P([4, -4, 1])
         Mr = M([[1, 2, 3], [4, 5, 6]])
-        # XXX: Fix fmpz_mat and fmpq_mat minpoly to not abort
-        if M is not flint.fmpz_mat and M is not flint.fmpq_mat:
-            assert raises(lambda: Mr.minpoly(), ValueError)
+        assert raises(lambda: Mr.minpoly(), ValueError)
 
 
 def test_matrices_rank():
     for M, S, is_field in _all_matrices():
-        # XXX: fmpq_mat doesn't support rank
-        if M is flint.fmpq_mat:
-            continue
         M1234 = M([[1, 2], [3, 4]])
         assert M1234.rank() == 2
         Mr = M([[1, 2, 3], [4, 5, 6]])

--- a/src/flint/types/fmpz_mat.pyx
+++ b/src/flint/types/fmpz_mat.pyx
@@ -126,7 +126,7 @@ cdef class fmpz_mat(flint_mat):
                     x = fmpz(entries[i*n + j])
                     fmpz_set(fmpz_mat_entry(self.val, i, j), (<fmpz>x).val)
         else:
-            raise ValueError("fmpz_mat: expected 1-3 arguments")
+            raise TypeError("fmpz_mat: expected 1-3 arguments")
 
     def __nonzero__(self):
         return not fmpz_mat_is_zero(self.val)
@@ -163,7 +163,7 @@ cdef class fmpz_mat(flint_mat):
         cdef fmpz x
         i, j = index
         if i < 0 or i >= self.nrows() or j < 0 or j >= self.ncols():
-            raise ValueError("index %i,%i exceeds matrix dimensions" % (i, j))
+            raise IndexError("index %i,%i exceeds matrix dimensions" % (i, j))
         x = fmpz.__new__(fmpz)
         fmpz_set(x.val, fmpz_mat_entry(self.val, i, j))
         return x
@@ -172,7 +172,7 @@ cdef class fmpz_mat(flint_mat):
         cdef long i, j
         i, j = index
         if i < 0 or i >= self.nrows() or j < 0 or j >= self.ncols():
-            raise ValueError("index %i,%i exceeds matrix dimensions" % (i, j))
+            raise IndexError("index %i,%i exceeds matrix dimensions" % (i, j))
         c = fmpz(value)  # XXX
         fmpz_set(fmpz_mat_entry(self.val, i, j), (<fmpz>c).val)
 
@@ -716,16 +716,47 @@ cdef class fmpz_mat(flint_mat):
         return bool(fmpz_mat_is_in_snf(self.val))
 
     def charpoly(self):
+        """Returns the characteristic polynomial of *self* as an *fmpz_poly*.
+
+        >>> from flint import fmpz_mat
+        >>> A = fmpz_mat(3, 3, range(9))
+        >>> A
+        [0, 1, 2]
+        [3, 4, 5]
+        [6, 7, 8]
+        >>> A.charpoly()
+        x^3 + (-12)*x^2 + (-18)*x
+        """
         cdef fmpz_poly u
+
+        if not fmpz_mat_is_square(self.val):
+            raise ValueError("matrix must be square")
+
         u = fmpz_poly.__new__(fmpz_poly)
         fmpz_poly_init(u.val)
         fmpz_mat_charpoly(u.val, self.val)
         return u
 
     def minpoly(self):
+        """Returns the minimal polynomial of *self* as an *fmpz_poly*.
+
+        >>> from flint import fmpz_mat
+        >>> A = fmpz_mat([[2, 1, 0], [0, 2, 0], [0, 0, 2]])
+        >>> A
+        [2, 1, 0]
+        [0, 2, 0]
+        [0, 0, 2]
+        >>> A.charpoly()
+        x^3 + (-6)*x^2 + 12*x + (-8)
+        >>> A.minpoly()
+        x^2 + (-4)*x + 4
+        """
         cdef fmpz_poly u
+
+        if not fmpz_mat_is_square(self.val):
+            raise ValueError("matrix must be square")
+
         u = fmpz_poly.__new__(fmpz_poly)
         fmpz_poly_init(u.val)
         fmpz_mat_minpoly(u.val, self.val)
         return u
-

--- a/src/flint/types/fmpz_mod.pyx
+++ b/src/flint/types/fmpz_mod.pyx
@@ -409,11 +409,14 @@ cdef class fmpz_mod(flint_scalar):
     def __bool__(self):
         return not self.is_zero()
 
-    def __repr__(self):
+    def repr(self):
         return "fmpz_mod({}, {})".format(
             fmpz_get_intlong(self.val),
             self.ctx.modulus()
         )
+
+    def __repr__(self):
+        return self.repr()
 
     def __hash__(self):
         return hash((int(self)))
@@ -421,8 +424,11 @@ cdef class fmpz_mod(flint_scalar):
     def __int__(self):
         return fmpz_get_intlong(self.val)
 
-    def __str__(self):
+    def str(self):
         return str(int(self))
+
+    def __str__(self):
+        return self.str()
 
     # ---------------- #
     #    Arithmetic    #

--- a/src/flint/types/fmpz_mod_mat.pxd
+++ b/src/flint/types/fmpz_mod_mat.pxd
@@ -1,0 +1,27 @@
+from flint.flintlib.flint cimport slong
+from flint.flintlib.fmpz cimport fmpz_t
+from flint.flintlib.fmpz_mod_mat cimport fmpz_mod_mat_t
+
+from flint.flint_base.flint_base cimport flint_mat
+from flint.types.fmpz_mod cimport fmpz_mod_ctx, fmpz_mod
+
+
+cdef class fmpz_mod_mat(flint_mat):
+    cdef fmpz_mod_mat_t val
+    cdef bint _initialized
+    cdef fmpz_mod_ctx ctx
+
+    cdef void _init_empty(self, slong m, slong n, list args)
+    cdef void _init_empty_ctx(self, slong m, slong n, fmpz_mod_ctx ctx)
+    cdef void _init_from_list(self, slong m, slong n, list entries, list args)
+    #cdef void _init_from_matrix(self, flint_mat M, list args)
+    cdef void _init_from_matrix(self, M, list args)
+    cdef fmpz_mod_ctx _parse_args(self, list args)
+    cdef fmpz_mod_mat _new(self, slong m, slong n, fmpz_mod_ctx ctx)
+    cdef fmpz_mod_mat _newlike(self)
+    cdef fmpz_mod_mat _copy(self)
+
+    cpdef slong nrows(self)
+    cpdef slong ncols(self)
+    cdef fmpz_mod _getitem(self, slong i, slong j)
+    cdef void _setitem(self, slong i, slong j, fmpz_t e)

--- a/src/flint/types/fmpz_mod_mat.pyx
+++ b/src/flint/types/fmpz_mod_mat.pyx
@@ -1,0 +1,656 @@
+from flint.utils.typecheck cimport (
+    typecheck,
+)
+from flint.flintlib.fmpz cimport (
+    fmpz_struct,
+    fmpz_t,
+    fmpz_init_set,
+    fmpz_set,
+)
+from flint.flintlib.fmpz_mod_mat cimport (
+    fmpz_mod_mat_init,
+    fmpz_mod_mat_init_set,
+    fmpz_mod_mat_clear,
+    fmpz_mod_mat_set,
+    fmpz_mod_mat_nrows,
+    fmpz_mod_mat_ncols,
+    fmpz_mod_mat_entry,
+    fmpz_mod_mat_set_entry,
+    fmpz_mod_mat_one,
+    fmpz_mod_mat_equal,
+    fmpz_mod_mat_is_zero,
+    fmpz_mod_mat_neg,
+    fmpz_mod_mat_add,
+    fmpz_mod_mat_sub,
+    fmpz_mod_mat_mul,
+    fmpz_mod_mat_scalar_mul_fmpz,
+    fmpz_mod_mat_inv,
+    fmpz_mod_mat_transpose,
+    fmpz_mod_mat_solve,
+    fmpz_mod_mat_rref,
+    fmpz_mod_mat_charpoly,
+    fmpz_mod_mat_minpoly,
+)
+
+from flint.flint_base.flint_base cimport (
+    flint_mat,
+)
+from flint.types.fmpz cimport (
+    fmpz,
+)
+from flint.types.nmod cimport (
+    nmod,
+)
+from flint.types.fmpz_mod cimport (
+    fmpz_mod_ctx,
+    fmpz_mod,
+)
+from flint.types.fmpz_mod_poly cimport (
+    fmpz_mod_poly,
+    fmpz_mod_poly_ctx,
+)
+from flint.types.fmpz_mat cimport (
+    fmpz_mat,
+)
+from flint.types.nmod_mat cimport (
+    nmod_mat,
+)
+
+
+cdef any_as_fmpz_mod_mat(x):
+    if typecheck(x, fmpz_mod_mat):
+        return x
+    elif typecheck(x, nmod_mat):
+        return fmpz_mod_mat(x)
+    else:
+        return NotImplemented
+
+
+cdef any_as_fmpz_mod_mat_ctx(x, fmpz_mod_ctx ctx):
+    y = any_as_fmpz_mod_mat(x)
+    if y is not NotImplemented:
+        return y
+    if typecheck(x, fmpz_mat):
+        return fmpz_mod_mat(x, ctx)
+    return NotImplemented
+
+
+cdef class fmpz_mod_mat(flint_mat):
+    """
+    The ``fmpz_mod_mat`` type represents dense matrices over ``Z/nZ`` for
+    arbitrary ``n`` (not necessarily word-sized unlike ``nmod_mat``). Some
+    operations may assume that n is a prime.
+    """
+    def __dealloc__(self):
+        if self._initialized:
+            fmpz_mod_mat_clear(self.val)
+
+    def __init__(self, *args):
+        """Construct an ``fmpz_mod_mat`` matrix.
+
+        >>> from flint import fmpz_mod_mat, fmpz_mod_ctx, fmpz_mat
+        >>> ctx = fmpz_mod_ctx(7)
+        >>> fmpz_mod_mat(2, 2, [1, 2, 3, 4], ctx)
+        [1, 2]
+        [3, 4]
+        >>> fmpz_mod_mat([[1, 2], [3, 4]], ctx)
+        [1, 2]
+        [3, 4]
+        >>> fmpz_mod_mat(2, 2, ctx)
+        [0, 0]
+        [0, 0]
+        >>> zmat = fmpz_mat(2, 2, [1, 2, 3, 4])
+        >>> fmpz_mod_mat(zmat, ctx)
+        [1, 2]
+        [3, 4]
+        """
+        # XXX: This logic should be moved to flint_mat.
+        if len(args) >= 2 and isinstance(args[0], int) and isinstance(args[1], int):
+            if len(args) >= 3 and isinstance(args[2], (list, tuple)):
+                m, n, entries, *arg = args
+                if len(entries) != m * n:
+                    raise ValueError("fmpz_mod_mat: invalid number of entries")
+                self._init_from_list(m, n, entries, arg)
+            else:
+                m, n, *arg = args
+                self._init_empty(m, n, arg)
+
+        elif (len(args) >= 1 and isinstance(args[0], (list, tuple))
+              and all(isinstance(arg, (list, tuple)) for arg in args[0])):
+            lol, *arg = args
+            m = len(lol)
+            if m == 0:
+                n = 0
+                entries = []
+            else:
+                n = len(lol[0])
+                if any(len(row) != n for row in lol):
+                    raise ValueError("fmpz_mod_mat: inconsistent row lengths")
+                entries = [x for row in lol for x in row]
+            self._init_from_list(m, n, entries, arg)
+
+        # XXX: nmod_mat is not a subclass of flint_mat (it should be)
+        elif len(args) >= 1 and isinstance(args[0], (flint_mat, nmod_mat)):
+            M, *arg = args
+            self._init_from_matrix(M, arg)
+
+        else:
+            raise TypeError("fmpz_mod_mat: invalid arguments")
+
+    cdef fmpz_mod_ctx _parse_args(self, list args):
+        """Parse the context argument."""
+        if len(args) != 1:
+            if len(args) == 0:
+                raise TypeError("fmpz_mod_mat: missing modulus argument")
+            else:
+                raise TypeError("fmpz_mod_mat: too many arguments")
+        arg = args[0]
+        if not typecheck(arg, fmpz_mod_ctx):
+            raise TypeError("fmpz_mod_mat: invalid modulus argument")
+        return arg
+
+    cdef void _init_empty_ctx(self, slong m, slong n, fmpz_mod_ctx ctx):
+        """Initialize an empty matrix with a given modulus context."""
+        self.ctx = ctx
+        fmpz_mod_mat_init(self.val, m, n, ctx.val.n)
+        self._initialized = True
+
+    cdef void _init_empty(self, slong m, slong n, list args):
+        """Initialize an empty matrix using the constructor arguments."""
+        cdef fmpz_mod_ctx ctx
+        ctx = self._parse_args(args)
+        self._init_empty_ctx(m, n, ctx)
+
+    cdef void _init_from_list(self, slong m, slong n, list entries, list args):
+        """Initialize a matrix from a list of entries."""
+        cdef fmpz_mod_ctx ctx
+        cdef fmpz_mod e
+        ctx = self._parse_args(args)
+        entries = [ctx.any_as_fmpz_mod(x) for x in entries]
+
+        self._init_empty_ctx(m, n, ctx)
+        for i in range(m):
+            for j in range(n):
+                val = ctx.any_as_fmpz_mod(entries[i*n + j])
+                if val is NotImplemented:
+                    raise TypeError("fmpz_mod_mat: incompatible entries")
+                e = <fmpz_mod> val
+                fmpz_mod_mat_set_entry(self.val, i, j, e.val)
+
+    # XXX: Should be possible to type this as flint_mat but nmod_mat is not a subclass
+    # cdef void _init_from_matrix(self, flint_mat M, list args):
+    cdef void _init_from_matrix(self, M, list args):
+        """Initialize from another matrix."""
+        cdef fmpz_mod_ctx ctx
+        cdef fmpz_mod_mat N1
+
+        if typecheck(M, fmpz_mod_mat):
+            N1 = M
+            if args:
+                ctx = self._parse_args(args)
+            else:
+                ctx = N1.ctx
+            if N1.ctx != ctx:
+                raise TypeError("fmpz_mod_mat: incompatible moduli")
+            fmpz_mod_mat_init_set(self.val, N1.val)
+            self.ctx = ctx
+            self._initialized = True
+        elif typecheck(M, fmpz_mat):
+            # XXX: This is inefficient.
+            self._init_from_list(M.nrows(), M.ncols(), M.entries(), args)
+        elif typecheck(M, nmod_mat):
+            m = M.modulus()
+            if args:
+                ctx = self._parse_args(args)
+                if m != ctx.modulus():
+                    raise TypeError("fmpz_mod_mat: incompatible moduli")
+            else:
+                ctx = fmpz_mod_ctx(m)
+            # XXX: This is inefficient.
+            entries = [int(x) for x in M.entries()]
+            self._init_from_list(M.nrows(), M.ncols(), entries, [ctx])
+        else:
+            raise TypeError("fmpz_mod_mat: unrocognized matrix type")
+
+    cdef fmpz_mod_mat _new(self, slong m, slong n, fmpz_mod_ctx ctx):
+        """Create an initialized matrix of given shape and context."""
+        cdef fmpz_mod_mat res
+        res = fmpz_mod_mat.__new__(fmpz_mod_mat)
+        fmpz_mod_mat_init(res.val, m, n, ctx.val.n)
+        res.ctx = ctx
+        res._initialized = True
+        return res
+
+    cdef fmpz_mod_mat _newlike(self):
+        """Create an uninitialized matrix of the same shape and context."""
+        return self._new(self.nrows(), self.ncols(), self.ctx)
+
+    cdef fmpz_mod_mat _copy(self):
+        """Create a copy of the matrix."""
+        cdef fmpz_mod_mat res
+        res = self._newlike()
+        fmpz_mod_mat_set(res.val, self.val)
+        return res
+
+    cpdef slong nrows(self):
+        """Return the number of rows."""
+        return fmpz_mod_mat_nrows(self.val)
+
+    cpdef slong ncols(self):
+        """Return the number of columns."""
+        return fmpz_mod_mat_ncols(self.val)
+
+    def modulus(self):
+        """Return the modulus."""
+        cdef fmpz mod
+        mod = fmpz.__new__(fmpz)
+        fmpz_init_set(mod.val, self.val.mod)
+        return mod
+
+    cdef fmpz_mod _getitem(self, slong i, slong j):
+        """Retrieve an element as an ``fmpz_mod``."""
+        cdef fmpz_struct * p_e
+        cdef fmpz_mod e
+        p_e = fmpz_mod_mat_entry(self.val, i, j)
+        e = fmpz_mod.__new__(fmpz_mod)
+        fmpz_set(e.val, p_e)
+        e.ctx = self.ctx
+        return e
+
+    cdef void _setitem(self, slong i, slong j, fmpz_t e):
+        """Set an element from a raw ``fmpz_t``."""
+        fmpz_mod_mat_set_entry(self.val, i, j, e)
+
+    def repr(self):
+        """Return a representation string."""
+        # XXX: Generic repr does not include modulus argument.
+        m = self.nrows()
+        n = self.ncols()
+        mod = self.modulus()
+        entries = (", ".join([x.repr() for x in self.entries()]))
+        return f"fmpz_mod_mat({m}, {n}, [{entries}], {mod})"
+
+    def entries(self):
+        """Return a list of entries."""
+        # XXX: Ideally move this to flint_mat
+        cdef slong i, j, m, n
+        m = self.nrows()
+        n = self.ncols()
+        L = [None] * (m * n)
+        for i from 0 <= i < m:
+            for j from 0 <= j < n:
+                L[i*n + j] = self._getitem(i, j)
+        return L
+
+    def __getitem__(self, index):
+        """Retrieve an element."""
+        # XXX: Ideally move this to flint_mat
+        cdef slong i, j
+        i, j = index
+        if i < 0 or i >= self.nrows() or j < 0 or j >= self.ncols():
+            raise ValueError("index %i,%i exceeds matrix dimensions" % (i, j))
+        return self._getitem(i, j)
+
+    def __setitem__(self, index, value):
+        """Set an element."""
+        cdef slong i, j
+        cdef fmpz_mod e
+        if not (isinstance(index, tuple) and len(index) == 2):
+            raise TypeError("fmpz_mod_mat indices must be 2-tuples")
+        i, j = index
+        if i < 0 or i >= self.nrows() or j < 0 or j >= self.ncols():
+            raise ValueError("index %i,%i exceeds matrix dimensions" % (i, j))
+        e = self.ctx.any_as_fmpz_mod(value)
+        self._setitem(i, j, e.val)
+
+    def __nonzero__(self):
+        """Return ``True`` if the matrix has any nonzero entries."""
+        cdef bint zero
+        zero = fmpz_mod_mat_is_zero(self.val)
+        return not zero
+
+    def __richcmp__(self, other, int op):
+        """Compare two matrices."""
+        cdef bint res
+
+        if op != 2 and op != 3:
+            raise TypeError("matrices cannot be ordered")
+
+        other = any_as_fmpz_mod_mat_ctx(other, self.ctx)
+        if other is NotImplemented:
+            return other
+
+        res = fmpz_mod_mat_equal((<fmpz_mod_mat>self).val, (<fmpz_mod_mat>other).val)
+
+        if op == 2:
+            return res
+        if op == 3:
+            return not res
+
+    def __pos__(self):
+        """``+M``: Return self (not a copy)."""
+        return self
+
+    def __neg__(self):
+        """``-M``"""
+        res = self._newlike()
+        fmpz_mod_mat_neg((<fmpz_mod_mat> res).val, self.val)
+        return res
+
+    def _as_fmpz_mod_mat(self, other, same_shape=True):
+        """Convert to ``fmpz_mod_mat`` but raise if shape or modulus do not match."""
+        cdef fmpz_mod_mat o
+        other = any_as_fmpz_mod_mat_ctx(other, self.ctx)
+        if other is NotImplemented:
+            return NotImplemented
+        o = other
+        if same_shape and not (self.nrows() == o.nrows() and self.ncols() == o.ncols()):
+            raise ValueError("Shape mismatch: cannot add matrices")
+        if self.ctx != o.ctx:
+            raise ValueError("fmpz_mod_mat: incompatible moduli")
+        return o
+
+    def _add(self, fmpz_mod_mat other):
+        """Add two ``fmpz_mod_mat`` matrices."""
+        res = self._newlike()
+        fmpz_mod_mat_add(res.val, self.val, other.val)
+        return res
+
+    def _sub(self, fmpz_mod_mat other):
+        """Subtract two ``fmpz_mod_mat`` matrices."""
+        res = self._newlike()
+        fmpz_mod_mat_sub(res.val, self.val, other.val)
+        return res
+
+    def _matmul(self, fmpz_mod_mat other):
+        """Multiply two ``fmpz_mod_mat`` matrices."""
+        if self.ncols() != other.nrows():
+            raise ValueError("Shape mismatch: cannot multiply matrices")
+        res = self._new(self.nrows(), other.ncols(), self.ctx)
+        fmpz_mod_mat_mul(res.val, self.val, other.val)
+        return res
+
+    def _scalarmul(self, fmpz_mod other):
+        """Multiply an ``fmpz_mod_mat`` matrix by an ``fmpz_mod`` scalar."""
+        res = self._newlike()
+        fmpz_mod_mat_scalar_mul_fmpz(res.val, self.val, other.val)
+        return res
+
+    def _pow(self, slong other):
+        """Raise an ``fmpz_mod_mat`` matrix to an integer power."""
+        cdef fmpz_mod_mat res, tmp
+
+        if self.nrows() != self.ncols():
+            raise ValueError("fmpz_mod_mat pow: matrix must be square")
+        if other < 0:
+            self = self.inv()
+            other = -other
+
+        res = self._newlike()
+        fmpz_mod_mat_one(res.val)
+
+        tmp = self._copy()
+
+        while other > 0:
+            if other % 2 == 1:
+                fmpz_mod_mat_mul(res.val, res.val, tmp.val)
+            fmpz_mod_mat_mul(tmp.val, tmp.val, tmp.val)
+            other //= 2
+
+        return res
+
+    def _div(self, fmpz_mod other):
+        """Divide an ``fmpz_mod_mat`` matrix by an ``fmpz_mod`` scalar."""
+        return self._scalarmul(other.inverse())
+
+    def __add__(self, other):
+        """``M + N``: Add two matrices."""
+        cdef fmpz_mod_mat o
+        other = self._as_fmpz_mod_mat(other)
+        if other is NotImplemented:
+            return NotImplemented
+        o = other
+        return self._add(other)
+
+    def __radd__(self, other):
+        """``N + M``: Add two matrices."""
+        cdef fmpz_mod_mat o
+        other = self._as_fmpz_mod_mat(other)
+        if other is NotImplemented:
+            return NotImplemented
+        o = other
+        return other._add(self)
+
+    def __sub__(self, other):
+        """``M - N``: Subtract two matrices."""
+        cdef fmpz_mod_mat o
+        other = self._as_fmpz_mod_mat(other)
+        if other is NotImplemented:
+            return NotImplemented
+        o = other
+        return self._sub(other)
+
+    def __rsub__(self, other):
+        """``N - M``: Subtract two matrices."""
+        cdef fmpz_mod_mat o
+        other = self._as_fmpz_mod_mat(other)
+        if other is NotImplemented:
+            return NotImplemented
+        o = other
+        return other._sub(self)
+
+    def __mul__(self, other):
+        """``M * N``: Multiply two matrices."""
+        cdef fmpz_mod_mat o
+        cdef fmpz_mod e
+        other_mat = self._as_fmpz_mod_mat(other, same_shape=False)
+        if other_mat is not NotImplemented:
+            o = other_mat
+            return self._matmul(other_mat)
+        other_scalar = self.ctx.any_as_fmpz_mod(other)
+        if other_scalar is not NotImplemented:
+            e = other_scalar
+            return self._scalarmul(e)
+        return NotImplemented
+
+    def __rmul__(self, other):
+        """``N * M``: Multiply two matrices."""
+        cdef fmpz_mod e
+        other_mat = self._as_fmpz_mod_mat(other)
+        if other_mat is not NotImplemented:
+            o = other_mat
+            return other_mat._matmul(self)
+        other_scalar = self.ctx.any_as_fmpz_mod(other)
+        if other_scalar is not NotImplemented:
+            e = other_scalar
+            return self._scalarmul(e)
+        return NotImplemented
+
+    def __pow__(self, other):
+        """``M ** n``: Raise a matrix to an integer power."""
+        if not isinstance(other, int):
+            return NotImplemented
+        return self._pow(other)
+
+    def __truediv__(self, other):
+        """``M / n``: Divide a matrix by a scalar."""
+        cdef fmpz_mod e
+        other_scalar = self.ctx.any_as_fmpz_mod(other)
+        if other_scalar is not NotImplemented:
+            e = other_scalar
+            return self._div(e)
+        return NotImplemented
+
+    def inv(self):
+        """Return the inverse of a matrix.
+
+        >>> from flint import fmpz_mod_mat, fmpz_mod_ctx
+        >>> ctx = fmpz_mod_ctx(7)
+        >>> M = fmpz_mod_mat([[1, 2], [3, 4]], ctx)
+        >>> M.inv()
+        [5, 1]
+        [5, 3]
+
+        Assumes that the modulus is prime.
+        """
+        cdef fmpz_mod_mat res
+        if self.nrows() != self.ncols():
+            raise ValueError("fmpz_mod_mat inv: matrix must be square")
+        res = self._newlike()
+        r = fmpz_mod_mat_inv(res.val, self.val)
+        if r == 0:
+            raise ZeroDivisionError("fmpz_mod_mat inv: matrix is not invertible")
+        return res
+
+    def det(self):
+        """Return the determinant of a matrix.
+
+        >>> from flint import fmpz_mod_mat, fmpz_mod_ctx
+        >>> ctx = fmpz_mod_ctx(7)
+        >>> M = fmpz_mod_mat([[1, 2], [3, 4]], ctx)
+        >>> M.det()
+        fmpz_mod(5, 7)
+
+        """
+        # XXX: No fmpz_mod_mat_det function...
+        p = self.charpoly()
+        p0 = p[0]
+        if self.nrows() % 2:
+            p0 = -p0
+        return p0
+
+    def charpoly(self):
+        """Return the characteristic polynomial of a matrix.
+
+        >>> from flint import fmpz_mod_mat, fmpz_mod_ctx
+        >>> ctx = fmpz_mod_ctx(7)
+        >>> M = fmpz_mod_mat([[1, 2], [3, 4]], ctx)
+        >>> M.charpoly()
+        x^2 + 2*x + 5
+
+        """
+        cdef fmpz_mod_poly_ctx pctx
+        cdef fmpz_mod_poly res
+
+        if self.nrows() != self.ncols():
+            raise ValueError("fmpz_mod_mat charpoly: matrix must be square")
+
+        pctx = fmpz_mod_poly_ctx(self.ctx)
+        res = fmpz_mod_poly(0, pctx)
+        fmpz_mod_mat_charpoly(res.val, self.val, self.ctx.val)
+        return res
+
+    def minpoly(self):
+        """Return the minimal polynomial of a matrix.
+
+        >>> from flint import fmpz_mod_mat, fmpz_mod_ctx
+        >>> ctx = fmpz_mod_ctx(7)
+        >>> M = fmpz_mod_mat([[2, 1, 0], [0, 2, 0], [0, 0, 2]], ctx)
+        >>> M.charpoly()
+        x^3 + x^2 + 5*x + 6
+        >>> M.minpoly()
+        x^2 + 3*x + 4
+
+        """
+        cdef fmpz_mod_poly_ctx pctx
+        cdef fmpz_mod_poly res
+
+        if self.nrows() != self.ncols():
+            raise ValueError("fmpz_mod_mat minpoly: matrix must be square")
+
+        pctx = fmpz_mod_poly_ctx(self.ctx)
+        res = fmpz_mod_poly(0, pctx)
+        fmpz_mod_mat_minpoly(res.val, self.val, self.ctx.val)
+        return res
+
+    def transpose(self):
+        """Return the transpose of a matrix.
+
+        >>> from flint import fmpz_mod_mat, fmpz_mod_ctx
+        >>> ctx = fmpz_mod_ctx(7)
+        >>> M = fmpz_mod_mat([[1, 2], [3, 4]], ctx)
+        >>> M
+        [1, 2]
+        [3, 4]
+        >>> M.transpose()
+        [1, 3]
+        [2, 4]
+        """
+        cdef fmpz_mod_mat res
+        res = self._new(self.ncols(), self.nrows(), self.ctx)
+        fmpz_mod_mat_transpose(res.val, self.val)
+        return res
+
+    def solve(self, rhs):
+        """Solve a linear system.
+
+        >>> from flint import fmpz_mod_mat, fmpz_mod_ctx
+        >>> ctx = fmpz_mod_ctx(7)
+        >>> M = fmpz_mod_mat([[1, 2], [3, 4]], ctx)
+        >>> rhs = fmpz_mod_mat([[5], [6]], ctx)
+        >>> M.solve(rhs)
+        [3]
+        [1]
+
+        The matrix must be square and invertible.
+
+        Assumes that the modulus is prime.
+        """
+        cdef bint success
+        cdef fmpz_mod_mat res
+
+        rhs = any_as_fmpz_mod_mat(rhs)
+
+        if rhs is NotImplemented:
+            raise TypeError("fmpz_mod_mat solve: invalid rhs")
+        if self.nrows() != self.ncols():
+            raise ValueError("fmpz_mod_mat solve: matrix must be square")
+        if self.nrows() != rhs.nrows():
+            raise ValueError("fmpz_mod_mat solve: shape mismatch")
+
+        res = self._new(rhs.nrows(), rhs.ncols(), self.ctx)
+        success = fmpz_mod_mat_solve(res.val, self.val, (<fmpz_mod_mat> rhs).val)
+
+        if not success:
+            raise ZeroDivisionError("Singular matrix in solve")
+
+        return res
+
+    def rank(self):
+        """Return the rank of a matrix.
+
+        >>> from flint import fmpz_mod_mat, fmpz_mod_ctx
+        >>> ctx = fmpz_mod_ctx(11)
+        >>> M = fmpz_mod_mat([[1, 2, 3], [4, 5, 6], [7, 8, 9]], ctx)
+        >>> M.rank()
+        2
+
+        Assumes that the modulus is prime.
+        """
+        return self.rref()[1]
+
+    def rref(self, inplace=False):
+        """Return the reduced row echelon form of a matrix and the rank.
+
+        >>> from flint import fmpz_mod_mat, fmpz_mod_ctx
+        >>> ctx = fmpz_mod_ctx(7)
+        >>> M = fmpz_mod_mat([[1, 2, 3], [4, 5, 6]], ctx)
+        >>> Mr, r = M.rref()
+        >>> Mr
+        [1, 0, 6]
+        [0, 1, 2]
+        >>> r
+        2
+
+        If ``inplace`` is ``True``, the matrix is modified in place.
+
+        Assumes that the modulus is prime.
+        """
+        cdef fmpz_mod_mat res
+        cdef slong r
+        if inplace:
+            res = self
+        else:
+            res = self._copy()
+        r = fmpz_mod_mat_rref(NULL, res.val)
+        return (res, r)

--- a/src/flint/types/fmpz_mod_mat.pyx
+++ b/src/flint/types/fmpz_mod_mat.pyx
@@ -288,7 +288,7 @@ cdef class fmpz_mod_mat(flint_mat):
         cdef slong i, j
         i, j = index
         if i < 0 or i >= self.nrows() or j < 0 or j >= self.ncols():
-            raise ValueError("index %i,%i exceeds matrix dimensions" % (i, j))
+            raise IndexError("index %i,%i exceeds matrix dimensions" % (i, j))
         return self._getitem(i, j)
 
     def __setitem__(self, index, value):
@@ -299,7 +299,7 @@ cdef class fmpz_mod_mat(flint_mat):
             raise TypeError("fmpz_mod_mat indices must be 2-tuples")
         i, j = index
         if i < 0 or i >= self.nrows() or j < 0 or j >= self.ncols():
-            raise ValueError("index %i,%i exceeds matrix dimensions" % (i, j))
+            raise IndexError("index %i,%i exceeds matrix dimensions" % (i, j))
         e = self.ctx.any_as_fmpz_mod(value)
         self._setitem(i, j, e.val)
 

--- a/src/flint/types/nmod_mat.pxd
+++ b/src/flint/types/nmod_mat.pxd
@@ -3,7 +3,7 @@ from flint.flint_base.flint_base cimport flint_mat
 from flint.flintlib.nmod_mat cimport nmod_mat_t
 from flint.flintlib.flint cimport mp_limb_t
 
-cdef class nmod_mat:
+cdef class nmod_mat(flint_mat):
     cdef nmod_mat_t val
     cpdef long nrows(self)
     cpdef long ncols(self)

--- a/src/flint/types/nmod_mat.pyx
+++ b/src/flint/types/nmod_mat.pyx
@@ -31,7 +31,7 @@ cdef any_as_nmod_mat(obj, nmod_t mod):
 
 cdef class nmod_mat:
     """
-    The nmod_poly type represents dense matrices over Z/nZ for
+    The nmod_mat type represents dense matrices over Z/nZ for
     word-size n. Some operations may assume that n is a prime.
     """
 

--- a/src/flint/utils/conversion.pxd
+++ b/src/flint/utils/conversion.pxd
@@ -1,5 +1,3 @@
-from cpython.version cimport PY_MAJOR_VERSION
-
 cdef inline long prec_to_dps(n):
     return max(1, int(round(int(n)/3.3219280948873626)-1))
 
@@ -7,29 +5,10 @@ cdef inline long dps_to_prec(n):
     return max(1, int(round((int(n)+1)*3.3219280948873626)))
 
 cdef inline chars_from_str(s):
-    if PY_MAJOR_VERSION < 3:
-        return s
-    else:
-        return s.encode('ascii')
+    return s.encode('ascii')
 
 cdef inline str_from_chars(s):
-    if PY_MAJOR_VERSION < 3:
-        return str(s)
-    else:
-        return bytes(s).decode('ascii')
-
-cdef inline matrix_to_str(tab):
-    if len(tab) == 0 or len(tab[0]) == 0:
-        return "[]"
-    tab = [[str(c) for c in row] for row in tab]
-    widths = []
-    for i in xrange(len(tab[0])):
-        w = max([len(row[i]) for row in tab])
-        widths.append(w)
-    for i in xrange(len(tab)):
-        tab[i] = [s.rjust(widths[j]) for j, s in enumerate(tab[i])]
-        tab[i] = "[" + (", ".join(tab[i])) + "]"
-    return "\n".join(tab)
+    return bytes(s).decode('ascii')
 
 cdef inline _str_trunc(s, trunc=0):
     if trunc > 0 and len(s) > 3 * trunc:
@@ -37,4 +16,3 @@ cdef inline _str_trunc(s, trunc=0):
         omitted = len(s) - left - right
         return s[:left] + ("{...%s digits...}" % omitted) + s[-right:]
     return s
-


### PR DESCRIPTION
Since fmpz_mod and fmpz_mod_poly were recently added (gh-87 gh-83) this PR adds the corresponding matrix type fmpz_mod_mat.

The tests added are mostly generic tests applied to the 4 exact matrix types fmpz_mat, fmpq_mat, nmod_mat and fmpz_mod_mat. Various methods are added to some of the other types so that they have more consistent interfaces. Also some exception types were changed and some cases where Flint would abort are now handled with Python exceptions (e.g. charpoly on a non-square matrix).

Also nmod_mat now subclasses flint_mat along with the other matrix types and the matrix printing was made more consistent in how ctx.pretty is handled.