### PR TITLE
pyproject.toml, setup.py: Only use numpy.distutils on win32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 requires = ["setuptools",
-            "numpy",
+            "numpy; sys_platform == 'win32' and python_version < '3.12'",
             "Cython>=3"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from Cython.Distutils import build_ext
 from Cython.Build import cythonize
 
 
-if sys.version_info < (3, 12):
+if sys.platform == 'win32' and sys.version_info < (3, 12):
     from distutils.core import setup
     from distutils.extension import Extension
     from numpy.distutils.system_info import default_include_dirs, default_lib_dirs


### PR DESCRIPTION
Using `setuptools` on all other platforms, as is already done when Python == 3.12 after #100.

Ref https://github.com/flintlib/python-flint/issues/52#issuecomment-1774196119 @oscarbenjamin 