### PR TITLE
.github/workflows/ci-sage.yml: New

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -8,8 +8,6 @@ name: Run Sage CI
 ##  - continuous integration, by building and testing other software
 ##    that depends on this project.
 ##
-## It runs on every pull request and push of a tag to the GitHub repository.
-##
 ## The testing can be monitored in the "Actions" tab of the GitHub repository.
 ##
 ## After all jobs have finished (or are canceled) and a short delay,
@@ -50,8 +48,6 @@ env:
   # Name of this project in the Sage distribution
   SPKG:             python_flint
   # Standard setting: Test the current beta release of Sage:
-  SAGE_REPO:        sagemath/sage
-  SAGE_REF:         develop
   REMOVE_PATCHES:   "*"
 
 jobs:
@@ -88,16 +84,17 @@ jobs:
     uses: sagemath/sage/.github/workflows/docker.yml@develop
     with:
       # Sage distribution packages to build
-      targets: SAGE_CHECK=no SAGE_CHECK_flint=yes SAGE_CHECK_python_flint=yes python_flint
+      targets:                  SAGE_CHECK=no SAGE_CHECK_flint=yes SAGE_CHECK_python_flint=yes python_flint
       # Standard setting: Test the current beta release of Sage:
-      sage_repo: sagemath/sage
-      sage_ref: develop
-      upstream_artifact: upstream
+      sage_repo:                sagemath/sage
+      sage_ref:                 refs/pull/37224/head
+      #sage_ref:                 develop
+      upstream_artifact:        upstream
       # Docker targets (stages) to tag
-      docker_targets: "with-targets"
+      docker_targets:           "with-targets"
       # We prefix the image name with the SPKG name ("python_flint_") to avoid the error
       # 'Package "sage-docker-..." is already associated with another repository.'
-      docker_push_repository: ghcr.io/${{ github.repository }}/python_flint_
+      docker_push_repository:   ghcr.io/${{ github.repository }}/python_flint_
     needs: [dist]
 
   macos:
@@ -106,10 +103,10 @@ jobs:
       osversion_xcodeversion_toxenv_tuples: >-
         [["latest", "",           "homebrew-macos-usrlocal-minimal"],
          ["latest", "",           "homebrew-macos-usrlocal-standard"]]
-      targets: SAGE_CHECK=no SAGE_CHECK_flint=yes SAGE_CHECK_python_flint=yes python_flint
+      targets:                  SAGE_CHECK=no SAGE_CHECK_flint=yes SAGE_CHECK_python_flint=yes python_flint
       # Standard setting: Test the current beta release of Sage:
-      sage_repo:         sagemath/sage
-      sage_ref:          refs/pull/37224/head
-      #sage_ref:          develop
-      upstream_artifact: upstream
+      sage_repo:                sagemath/sage
+      sage_ref:                 refs/pull/37224/head
+      #sage_ref:                 develop
+      upstream_artifact:        upstream
     needs: [dist]

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -1,0 +1,114 @@
+name: Run Sage CI
+
+## This GitHub Actions workflow provides:
+##
+##  - portability testing, by building and testing this project on many platforms
+##    (Linux variants and Cygwin), each with two configurations (installed packages),
+##
+##  - continuous integration, by building and testing other software
+##    that depends on this project.
+##
+## It runs on every pull request and push of a tag to the GitHub repository.
+##
+## The testing can be monitored in the "Actions" tab of the GitHub repository.
+##
+## After all jobs have finished (or are canceled) and a short delay,
+## tar files of all logs are made available as "build artifacts".
+##
+## This GitHub Actions workflow uses the portability testing framework
+## of SageMath (https://www.sagemath.org/).  For more information, see
+## https://doc.sagemath.org/html/en/developer/portability_testing.html
+
+## The workflow consists of two jobs:
+##
+##  - First, it builds a source distribution of the project
+##    and generates a script "update-pkgs.sh".  It uploads them
+##    as a build artifact named upstream.
+##
+##  - Second, it checks out a copy of the SageMath source tree.
+##    It downloads the upstream artifact and replaces the project's
+##    package in the SageMath distribution by the newly packaged one
+##    from the upstream artifact, by running the script "update-pkgs.sh".
+##    Then it builds a small portion of the Sage distribution.
+##
+## Many copies of the second step are run in parallel for each of the tested
+## systems/configurations.
+
+on:
+  push:
+    tags:
+      - '*'
+  schedule:
+    # run each Wednesday at 01:00
+    - cron: '0 1 * * 3'
+  workflow_dispatch:
+    # Allow to run manually
+
+env:
+  # Ubuntu packages to install so that the project's "make dist" can succeed
+  DIST_PREREQ:
+  # Name of this project in the Sage distribution
+  SPKG:             python_flint
+  # Standard setting: Test the current beta release of Sage:
+  SAGE_REPO:        sagemath/sage
+  SAGE_REF:         develop
+  REMOVE_PATCHES:   "*"
+
+jobs:
+
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out ${{ env.SPKG }}
+        uses: actions/checkout@v4
+        with:
+          path: build/pkgs/${{ env.SPKG }}/src
+      - name: Install prerequisites
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install $DIST_PREREQ
+        if: env.DIST_PREREQ != ''
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: pip install build
+      - name: Run make dist, prepare upstream artifact
+        run: |
+          (cd build/pkgs/${{ env.SPKG }}/src && python -m build --sdist) \
+          && mkdir -p upstream && cp build/pkgs/${{ env.SPKG }}/src/dist/*.tar.gz upstream/${{ env.SPKG }}-git.tar.gz \
+          && echo "sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=standard" > upstream/update-pkgs.sh \
+          && if [ -n "${{ env.REMOVE_PATCHES }}" ]; then echo "(cd ../build/pkgs/${{ env.SPKG }}/patches && rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh; fi \
+          && ls -l upstream/
+      - uses: actions/upload-artifact@v2
+        with:
+          path: upstream
+          name: upstream
+
+  linux:
+    uses: sagemath/sage/.github/workflows/docker.yml@develop
+    with:
+      # Sage distribution packages to build
+      targets: SAGE_CHECK=no SAGE_CHECK_flint=yes SAGE_CHECK_python_flint=yes python_flint
+      # Standard setting: Test the current beta release of Sage:
+      sage_repo: sagemath/sage
+      sage_ref: develop
+      upstream_artifact: upstream
+      # Docker targets (stages) to tag
+      docker_targets: "with-targets"
+      # We prefix the image name with the SPKG name ("python_flint_") to avoid the error
+      # 'Package "sage-docker-..." is already associated with another repository.'
+      docker_push_repository: ghcr.io/${{ github.repository }}/python_flint_
+    needs: [dist]
+
+  macos:
+    uses: sagemath/sage/.github/workflows/macos.yml@develop
+    with:
+      osversion_xcodeversion_toxenv_tuples: >-
+        [["latest", "",           "homebrew-macos-usrlocal-minimal"],
+         ["latest", "",           "homebrew-macos-usrlocal-standard"]]
+      targets: SAGE_CHECK=no SAGE_CHECK_flint=yes SAGE_CHECK_python_flint=yes python_flint
+      # Standard setting: Test the current beta release of Sage:
+      sage_repo:         sagemath/sage
+      sage_ref:          develop
+      upstream_artifact: upstream
+    needs: [dist]

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -109,6 +109,7 @@ jobs:
       targets: SAGE_CHECK=no SAGE_CHECK_flint=yes SAGE_CHECK_python_flint=yes python_flint
       # Standard setting: Test the current beta release of Sage:
       sage_repo:         sagemath/sage
-      sage_ref:          develop
+      sage_ref:          refs/pull/37224/head
+      #sage_ref:          develop
       upstream_artifact: upstream
     needs: [dist]

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -84,7 +84,7 @@ jobs:
     uses: sagemath/sage/.github/workflows/docker.yml@develop
     with:
       # Sage distribution packages to build
-      targets:                  SAGE_CHECK=no SAGE_CHECK_flint=yes SAGE_CHECK_python_flint=yes python_flint
+      targets:                  SAGE_CHECK=no SAGE_CHECK_flint=warn SAGE_CHECK_python_flint=yes python_flint
       # Standard setting: Test the current beta release of Sage:
       sage_repo:                sagemath/sage
       sage_ref:                 refs/pull/37224/head
@@ -103,7 +103,7 @@ jobs:
       osversion_xcodeversion_toxenv_tuples: >-
         [["latest", "",           "homebrew-macos-usrlocal-minimal"],
          ["latest", "",           "homebrew-macos-usrlocal-standard"]]
-      targets:                  SAGE_CHECK=no SAGE_CHECK_flint=yes SAGE_CHECK_python_flint=yes python_flint
+      targets:                  SAGE_CHECK=no SAGE_CHECK_flint=warn SAGE_CHECK_python_flint=yes python_flint
       # Standard setting: Test the current beta release of Sage:
       sage_repo:                sagemath/sage
       sage_ref:                 refs/pull/37224/head


### PR DESCRIPTION
This adds portability and integration testing using the reusable GH Actions workflows of SageMath. 

python-flint is added to Sage in https://github.com/sagemath/sage/pull/37224

Based on the discussion in https://github.com/flintlib/flint/pull/1760, it is configured to only run as a weekly cron job and on tags, not on individual PRs.

Preview: https://github.com/mkoeppe/python-flint/actions/runs/7762469133
