### PR TITLE
Build modernization based on pyproject.toml

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -68,9 +68,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - run: pip install --upgrade pip
-      - run: pip install cython setuptools
-      - run: python setup.py sdist
+      - run: pip install build
+      - run: python -m build --sdist
 
       - uses: actions/upload-artifact@v4
         with:

--- a/bin/pip_install_ubuntu.sh
+++ b/bin/pip_install_ubuntu.sh
@@ -41,16 +41,12 @@ cd ..
 ls -l /usr/local/lib
 sudo ldconfig /usr/local/lib
 
-# Python build requirements. Ideally these would be in pyproject.toml, but
-# first need to migrate from setup.py to pyproject.toml.
-pip install numpy cython setuptools wheel
-
 # Install from checkout (or sdist).
 echo -----------------------------------------------------------
 echo
 echo     Running:
-echo        $ pip install --no-binary :all: --no-build-isolation $1
+echo        $ pip install --no-binary python-flint $1
 echo
 echo -----------------------------------------------------------
 
-pip install --no-binary :all: --no-build-isolation $1
+pip install --no-binary python-flint $1


### PR DESCRIPTION
Getting rid of a direct invocation of `setup.py sdist` (deprecated in favor of using a build front-end)

Using build isolation in `bin/pip_install_ubuntu.sh`
