### PR TITLE
pyproject.toml: Move settings of CIBW_* here

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -48,8 +48,6 @@ jobs:
             LIBRARY_PATH=$(pwd)/.local/lib/
             LD_LIBRARY_PATH=$(pwd)/.local/lib:$LD_LIBRARY_PATH
             PYTHON_FLINT_MINGW64=true
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
-            bin\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          # override setting in pyproject.toml to use msys2 instead of msys64 bash
           CIBW_BEFORE_ALL_WINDOWS: msys2 -c bin/cibw_before_all_windows.sh
           CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel && msys2 -c bin/cibw_before_build_windows.sh
 

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -38,8 +38,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_MACOS: bin/cibw_before_all_macosx_x86_64.sh
           CIBW_BEFORE_ALL_WINDOWS: msys2 -c bin/cibw_before_all_windows.sh
-          CIBW_BEFORE_BUILD_WINDOWS: msys2 -c bin/cibw_before_build_windows.sh
-          CIBW_BEFORE_BUILD: pip install numpy setuptools cython delvewheel
+          CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel && msys2 -c bin/cibw_before_build_windows.sh
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           # override setting in pyproject.toml to use msys2 instead of msys64 bash
           CIBW_BEFORE_ALL_WINDOWS: msys2 -c bin/cibw_before_all_windows.sh
           CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel && msys2 -c bin/cibw_before_build_windows.sh

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -38,7 +38,6 @@ jobs:
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_LINUX: bin/cibw_before_all_linux.sh
           CIBW_BEFORE_ALL_MACOS: bin/cibw_before_all_macosx_x86_64.sh
           CIBW_BEFORE_ALL_WINDOWS: msys2 -c bin/cibw_before_all_windows.sh
           CIBW_BEFORE_BUILD_WINDOWS: msys2 -c bin/cibw_before_build_windows.sh

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -47,7 +47,6 @@ jobs:
             C_INCLUDE_PATH=$(pwd)/.local/include/
             LIBRARY_PATH=$(pwd)/.local/lib/
             LD_LIBRARY_PATH=$(pwd)/.local/lib:$LD_LIBRARY_PATH
-            PYTHON_FLINT_MINGW64=true
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -50,7 +50,6 @@ jobs:
             PYTHON_FLINT_MINGW64=true
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
             bin\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}
-          CIBW_TEST_COMMAND: python -c "import flint; print(str(flint.fmpz(2)))"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -43,10 +43,6 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: msys2 -c bin/cibw_before_all_windows.sh
           CIBW_BEFORE_BUILD_WINDOWS: msys2 -c bin/cibw_before_build_windows.sh
           CIBW_BEFORE_BUILD: pip install numpy setuptools cython delvewheel
-          CIBW_ENVIRONMENT: >
-            C_INCLUDE_PATH=$(pwd)/.local/include/
-            LIBRARY_PATH=$(pwd)/.local/lib/
-            LD_LIBRARY_PATH=$(pwd)/.local/lib:$LD_LIBRARY_PATH
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_MACOS: bin/cibw_before_all_macosx_x86_64.sh

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -36,7 +36,6 @@ jobs:
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_MACOS: bin/cibw_before_all_macosx_x86_64.sh
           CIBW_BEFORE_ALL_WINDOWS: msys2 -c bin/cibw_before_all_windows.sh
           CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel && msys2 -c bin/cibw_before_build_windows.sh
 

--- a/bin/build_dependencies_unix.sh
+++ b/bin/build_dependencies_unix.sh
@@ -174,7 +174,7 @@ if [ $USE_GMP = "gmp" ]; then
         --enable-shared=yes\
         --enable-static=no\
         --host=$HOST_ARG
-      make -j3
+      make -j6
       make install
 
     cd ..
@@ -195,7 +195,7 @@ else
   tar xf yasm-$YASMVER.tar.gz
   cd yasm-$YASMVER
     ./configure --prefix=$PREFIX
-    make -j3
+    make -j6
     make install
   cd ..
 
@@ -226,7 +226,7 @@ else
       --enable-shared=yes\
       --enable-static=no\
       --enable-gmpcompat
-    make -j3
+    make -j6
     make install
   cd ..
 
@@ -260,7 +260,7 @@ else
       --with-gmp=$PREFIX\
       --enable-shared=yes\
       --enable-static=no
-    make -j3
+    make -j6
     make install
   cd ..
 fi
@@ -285,7 +285,7 @@ cd flint-$FLINTVER
     $FLINTARB_WITHGMP\
     --with-mpfr=$PREFIX\
     --disable-static
-  make -j3
+  make -j6
   make install
 cd ..
 
@@ -312,7 +312,7 @@ if [ $BUILD_ARB = "yes" ]; then
       $FLINTARB_WITHGMP\
       --with-mpfr=$PREFIX\
       --disable-static
-    make -j3
+    make -j6
     make install
     #
     # Set PATH so that DLLs are picked up on Windows.

--- a/bin/cibw.bat
+++ b/bin/cibw.bat
@@ -24,7 +24,4 @@ del /q wheelhouse\*
 rem override setting in pyproject.toml
 set CIBW_BUILD=cp39-* cp310-* cp311-*
 
-set CIBW_BEFORE_ALL_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_all_windows.sh
-set CIBW_BEFORE_BUILD_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_build_windows.sh
-
 cibuildwheel --platform windows

--- a/bin/cibw.bat
+++ b/bin/cibw.bat
@@ -27,6 +27,5 @@ set CIBW_BEFORE_ALL_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_all_windows.s
 set CIBW_BEFORE_BUILD_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_build_windows.sh
 set CIBW_ENVIRONMENT=PYTHON_FLINT_MINGW64=true
 set CIBW_REPAIR_WHEEL_COMMAND_WINDOWS=bin\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}
-set CIBW_TEST_COMMAND=python -c "import flint; print(str(flint.fmpz(2)))"
 
 cibuildwheel --platform windows

--- a/bin/cibw.bat
+++ b/bin/cibw.bat
@@ -26,6 +26,5 @@ set CIBW_SKIP=*-win32 *-manylinux_i686 *-musllinux_*
 set CIBW_BEFORE_ALL_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_all_windows.sh
 set CIBW_BEFORE_BUILD_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_build_windows.sh
 set CIBW_ENVIRONMENT=PYTHON_FLINT_MINGW64=true
-set CIBW_REPAIR_WHEEL_COMMAND_WINDOWS=bin\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}
 
 cibuildwheel --platform windows

--- a/bin/cibw.bat
+++ b/bin/cibw.bat
@@ -21,7 +21,9 @@ rem wheels from a previous run so we delete them here.
 rem
 del /q wheelhouse\*
 
+rem override setting in pyproject.toml
 set CIBW_BUILD=cp39-* cp310-* cp311-*
+
 set CIBW_SKIP=*-win32 *-manylinux_i686 *-musllinux_*
 set CIBW_BEFORE_ALL_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_all_windows.sh
 set CIBW_BEFORE_BUILD_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_build_windows.sh

--- a/bin/cibw.bat
+++ b/bin/cibw.bat
@@ -24,7 +24,6 @@ del /q wheelhouse\*
 rem override setting in pyproject.toml
 set CIBW_BUILD=cp39-* cp310-* cp311-*
 
-set CIBW_SKIP=*-win32 *-manylinux_i686 *-musllinux_*
 set CIBW_BEFORE_ALL_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_all_windows.sh
 set CIBW_BEFORE_BUILD_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_build_windows.sh
 

--- a/bin/cibw.bat
+++ b/bin/cibw.bat
@@ -25,6 +25,5 @@ set CIBW_BUILD=cp39-* cp310-* cp311-*
 set CIBW_SKIP=*-win32 *-manylinux_i686 *-musllinux_*
 set CIBW_BEFORE_ALL_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_all_windows.sh
 set CIBW_BEFORE_BUILD_WINDOWS=C:\msys64\usr\bin\bash bin/cibw_before_build_windows.sh
-set CIBW_ENVIRONMENT=PYTHON_FLINT_MINGW64=true
 
 cibuildwheel --platform windows

--- a/bin/cibw.sh
+++ b/bin/cibw.sh
@@ -26,8 +26,6 @@ export CIBW_BEFORE_ALL_WINDOWS='C:\\msys64\\usr\\bin\\bash bin/cibw_before_all_w
 export CIBW_BEFORE_BUILD='pip install numpy cython delvewheel'
 export CIBW_BEFORE_BUILD_WINDOWS='C:\\msys64\\usr\\bin\\bash bin/cibw_before_build_windows.sh'
 
-export CIBW_REPAIR_WHEEL_COMMAND_WINDOWS='bin\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}'
-
 export CIBW_TEST_COMMAND="python -m flint.test"  # override setting in pyproject.toml
 
 # cibuildwheel --platform linux

--- a/bin/cibw.sh
+++ b/bin/cibw.sh
@@ -8,9 +8,6 @@
 
 rm -f wheelhouse/*
 
-# bin/build_dependencies_unix.sh places headers and shared libraries under .local
-export CIBW_ENVIRONMENT='C_INCLUDE_PATH=$(pwd)/.local/include/ LIBRARY_PATH=$(pwd)/.local/lib/ LD_LIBRARY_PATH=$(pwd)/.local/lib:$LD_LIBRARY_PATH'
-
 export CIBW_BUILD='cp39-* cp310-* cp311-* cp312-*'
 # export CIBW_BUILD='cp311-*'
 export CIBW_SKIP='*-win32 *-manylinux_i686 *-musllinux_*'

--- a/bin/cibw.sh
+++ b/bin/cibw.sh
@@ -15,7 +15,6 @@ export CIBW_SKIP='*-win32 *-manylinux_i686 *-musllinux_*'
 # export CIBW_ARCHS_MACOS="x86_64"
 export CIBW_ARCHS_MACOS="arm64"
 
-export CIBW_BEFORE_ALL_LINUX=bin/cibw_before_all_linux.sh
 # export CIBW_BEFORE_ALL_MACOS=bin/cibw_before_all_macosx_x86_64.sh
 export CIBW_BEFORE_ALL_MACOS=bin/cibw_before_all_macosx_arm64.sh
 export CIBW_BEFORE_ALL_WINDOWS='C:\\msys64\\usr\\bin\\bash bin/cibw_before_all_windows.sh'

--- a/bin/cibw.sh
+++ b/bin/cibw.sh
@@ -9,7 +9,7 @@
 rm -f wheelhouse/*
 
 # bin/build_dependencies_unix.sh places headers and shared libraries under .local
-export CIBW_ENVIRONMENT='C_INCLUDE_PATH=$(pwd)/.local/include/ LIBRARY_PATH=$(pwd)/.local/lib/ LD_LIBRARY_PATH=$(pwd)/.local/lib:$LD_LIBRARY_PATH PYTHON_FLINT_MINGW64=true'
+export CIBW_ENVIRONMENT='C_INCLUDE_PATH=$(pwd)/.local/include/ LIBRARY_PATH=$(pwd)/.local/lib/ LD_LIBRARY_PATH=$(pwd)/.local/lib:$LD_LIBRARY_PATH'
 
 export CIBW_BUILD='cp39-* cp310-* cp311-* cp312-*'
 # export CIBW_BUILD='cp311-*'

--- a/bin/cibw.sh
+++ b/bin/cibw.sh
@@ -8,8 +8,6 @@
 
 rm -f wheelhouse/*
 
-export CIBW_BUILD='cp39-* cp310-* cp311-* cp312-*'
-# export CIBW_BUILD='cp311-*'
 export CIBW_SKIP='*-win32 *-manylinux_i686 *-musllinux_*'
 
 # export CIBW_ARCHS_MACOS="x86_64"

--- a/bin/cibw.sh
+++ b/bin/cibw.sh
@@ -11,8 +11,6 @@ rm -f wheelhouse/*
 # export CIBW_ARCHS_MACOS="x86_64"
 export CIBW_ARCHS_MACOS="arm64"
 
-# export CIBW_BEFORE_ALL_MACOS=bin/cibw_before_all_macosx_x86_64.sh
-export CIBW_BEFORE_ALL_MACOS=bin/cibw_before_all_macosx_arm64.sh
 export CIBW_BEFORE_ALL_WINDOWS='C:\\msys64\\usr\\bin\\bash bin/cibw_before_all_windows.sh'
 
 export CIBW_BEFORE_BUILD_WINDOWS='pip install delvewheel && C:\\msys64\\usr\\bin\\bash bin/cibw_before_build_windows.sh'

--- a/bin/cibw.sh
+++ b/bin/cibw.sh
@@ -28,8 +28,7 @@ export CIBW_BEFORE_BUILD_WINDOWS='C:\\msys64\\usr\\bin\\bash bin/cibw_before_bui
 
 export CIBW_REPAIR_WHEEL_COMMAND_WINDOWS='bin\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}'
 
-# export CIBW_TEST_COMMAND="python -c 'import flint; print(str(flint.fmpz(2)))'"
-export CIBW_TEST_COMMAND="python -m flint.test"
+export CIBW_TEST_COMMAND="python -m flint.test"  # override setting in pyproject.toml
 
 # cibuildwheel --platform linux
 # cibuildwheel --platform windows

--- a/bin/cibw.sh
+++ b/bin/cibw.sh
@@ -8,8 +8,6 @@
 
 rm -f wheelhouse/*
 
-export CIBW_SKIP='*-win32 *-manylinux_i686 *-musllinux_*'
-
 # export CIBW_ARCHS_MACOS="x86_64"
 export CIBW_ARCHS_MACOS="arm64"
 

--- a/bin/cibw.sh
+++ b/bin/cibw.sh
@@ -11,10 +11,6 @@ rm -f wheelhouse/*
 # export CIBW_ARCHS_MACOS="x86_64"
 export CIBW_ARCHS_MACOS="arm64"
 
-export CIBW_BEFORE_ALL_WINDOWS='C:\\msys64\\usr\\bin\\bash bin/cibw_before_all_windows.sh'
-
-export CIBW_BEFORE_BUILD_WINDOWS='pip install delvewheel && C:\\msys64\\usr\\bin\\bash bin/cibw_before_build_windows.sh'
-
 export CIBW_TEST_COMMAND="python -m flint.test"  # override setting in pyproject.toml
 
 # cibuildwheel --platform linux

--- a/bin/cibw.sh
+++ b/bin/cibw.sh
@@ -15,8 +15,7 @@ export CIBW_ARCHS_MACOS="arm64"
 export CIBW_BEFORE_ALL_MACOS=bin/cibw_before_all_macosx_arm64.sh
 export CIBW_BEFORE_ALL_WINDOWS='C:\\msys64\\usr\\bin\\bash bin/cibw_before_all_windows.sh'
 
-export CIBW_BEFORE_BUILD='pip install numpy cython delvewheel'
-export CIBW_BEFORE_BUILD_WINDOWS='C:\\msys64\\usr\\bin\\bash bin/cibw_before_build_windows.sh'
+export CIBW_BEFORE_BUILD_WINDOWS='pip install delvewheel && C:\\msys64\\usr\\bin\\bash bin/cibw_before_build_windows.sh'
 
 export CIBW_TEST_COMMAND="python -m flint.test"  # override setting in pyproject.toml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ LIBRARY_PATH = "$(pwd)/.local/lib/"
 LD_LIBRARY_PATH = "$(pwd)/.local/lib:$LD_LIBRARY_PATH"
 
 [tool.cibuildwheel.linux]
+before-all = "bin/cibw_before_all_linux.sh"
 
 [tool.cibuildwheel.macos]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ content-type = "text/markdown"
 
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-*"
+skip = "*-win32 *-manylinux_i686 *-musllinux_*"
 test-command = "python -c \"import flint; print(str(flint.fmpz(2)))\""
 
 [tool.cibuildwheel.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ LD_LIBRARY_PATH = "$(pwd)/.local/lib:$LD_LIBRARY_PATH"
 before-all = "bin/cibw_before_all_linux.sh"
 
 [tool.cibuildwheel.macos]
+before-all = "bin/cibw_before_all_macosx_$(uname -m).sh"
 
 [tool.cibuildwheel.windows]
 repair-wheel-command = "bin\\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ before-all = "bin/cibw_before_all_linux.sh"
 before-all = "bin/cibw_before_all_macosx_$(uname -m).sh"
 
 [tool.cibuildwheel.windows]
+before-all = "C:\\msys64\\usr\\bin\\bash bin/cibw_before_all_windows.sh"
+before-build = "pip install delvewheel && C:\\msys64\\usr\\bin\\bash bin/cibw_before_build_windows.sh"
 repair-wheel-command = "bin\\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ content-type = "text/markdown"
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux_*"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
 test-command = "python -c \"import flint; print(str(flint.fmpz(2)))\""
 
 [tool.cibuildwheel.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,18 @@ content-type = "text/markdown"
 [tool.cibuildwheel]
 test-command = "python -c \"import flint; print(str(flint.fmpz(2)))\""
 
+[tool.cibuildwheel.environment]
+# bin/build_dependencies_unix.sh places headers and shared libraries under .local
+C_INCLUDE_PATH = "$(pwd)/.local/include/"
+LIBRARY_PATH = "$(pwd)/.local/lib/"
+LD_LIBRARY_PATH = "$(pwd)/.local/lib:$LD_LIBRARY_PATH"
+
 [tool.cibuildwheel.linux]
 
 [tool.cibuildwheel.macos]
 
 [tool.cibuildwheel.windows]
-environment = { PYTHON_FLINT_MINGW64="true" }
 repair-wheel-command = "bin\\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}"
+
+[tool.cibuildwheel.windows.environment]
+PYTHON_FLINT_MINGW64 = "true"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,10 @@ content-type = "text/markdown"
 
 [tool.cibuildwheel]
 test-command = "python -c \"import flint; print(str(flint.fmpz(2)))\""
+
+[tool.cibuildwheel.linux]
+
+[tool.cibuildwheel.macos]
+
+[tool.cibuildwheel.windows]
+repair-wheel-command = "bin\\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,4 +29,5 @@ test-command = "python -c \"import flint; print(str(flint.fmpz(2)))\""
 [tool.cibuildwheel.macos]
 
 [tool.cibuildwheel.windows]
+environment = { PYTHON_FLINT_MINGW64="true" }
 repair-wheel-command = "bin\\cibw_repair_wheel_command_windows.bat {dest_dir} {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ classifiers = [
 [project.readme]
 file = "README.md"
 content-type = "text/markdown"
+
+[tool.cibuildwheel]
+test-command = "python -c \"import flint; print(str(flint.fmpz(2)))\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ file = "README.md"
 content-type = "text/markdown"
 
 [tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-*"
 test-command = "python -c \"import flint; print(str(flint.fmpz(2)))\""
 
 [tool.cibuildwheel.environment]


### PR DESCRIPTION
As suggested in https://github.com/flintlib/python-flint/pull/108#issuecomment-1909901282 @oscarbenjamin 

Also increasing build parallelism in CI because GH Actions upgraded to machines with 4 CPUs in late 2023. (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories). (`make -j6` was a first guess, reducing the wall time of "Build wheels for macos-12" from 28 min to 17 min and "Build wheels for windows-2019" from 28 min to 26 min.)
