### PR TITLE
maint: bump Flint to 3.1.0

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -129,8 +129,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # minimum supported version and latest git
-        flinttag: ['v3.0.0', 'main']
+        # Supported versions and latest git
+        flinttag: ['v3.0.0', 'v3.0.1', 'v3.1.0', 'main']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ To do
 CHANGELOG
 -------------
 
+Next release:
+
+- Bump Flint version to 3.1.0
+
 0.6.0
 
 - [gh-112](https://github.com/flintlib/python-flint/issues/112),

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ CHANGELOG
 
 Next release:
 
-- Bump Flint version to 3.1.0
+- [gh-125](https://github.com/flintlib/python-flint/pull/125)
+  Bump Flint version to 3.1.0
 
 0.6.0
 

--- a/bin/build_variables.sh
+++ b/bin/build_variables.sh
@@ -21,4 +21,4 @@ MPIRVER=3.0.0 # MPIR build no longer works (not clear where to download from)
 # These are the actual dependencies used (at least by default):
 GMPVER=6.3.0
 MPFRVER=4.1.0
-FLINTVER=3.0.1
+FLINTVER=3.1.0

--- a/bin/pip_install_ubuntu.sh
+++ b/bin/pip_install_ubuntu.sh
@@ -23,7 +23,7 @@ set -o errexit
 if [ -z "$2" ]; then
     echo "Building from release tarball"
     FLINT_GIT=""
-    FLINTVER=3.1.0
+    FLINTVER=3.0.1
 else
     echo "Building from git: $2"
     FLINT_GIT=$2

--- a/bin/pip_install_ubuntu.sh
+++ b/bin/pip_install_ubuntu.sh
@@ -23,7 +23,7 @@ set -o errexit
 if [ -z "$2" ]; then
     echo "Building from release tarball"
     FLINT_GIT=""
-    FLINTVER=3.0.1
+    FLINTVER=3.1.0
 else
     echo "Building from git: $2"
     FLINT_GIT=$2


### PR DESCRIPTION
Flint 3.1.0 is released:

https://groups.google.com/g/flint-devel/c/36-dOb0Sfqc/m/By2w0cs5AQAJ?utm_medium=email&utm_source=footer