### PR TITLE
fix: Remove all references to Python 2's long type

### DIFF
--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -9,9 +9,6 @@ from flint.utils.flint_exceptions import DomainError
 
 import flint
 
-if sys.version_info[0] >= 3:
-    long = int
-
 PYPY = platform.python_implementation() == "PyPy"
 
 ctx = flint.ctx
@@ -95,8 +92,8 @@ def test_fmpz():
     assert raises(lambda: flint.fmpz([]), TypeError)
     for s in L:
         for t in L:
-            for ltype in (flint.fmpz, int, long):
-                for rtype in (flint.fmpz, int, long):
+            for ltype in (flint.fmpz, int):
+                for rtype in (flint.fmpz, int):
 
                     assert (ltype(s) == rtype(t)) == (s == t)
                     assert (ltype(s) != rtype(t)) == (s != t)
@@ -370,7 +367,7 @@ def test_fmpz_poly():
     assert raises(lambda: Z({}), TypeError)
     # XXX: This should probably be made to work:
     assert raises(lambda: Z((1,2,3)), TypeError)
-    for ztype in [int, long, flint.fmpz]:
+    for ztype in [int, flint.fmpz]:
         assert Z([1,2,3]) + ztype(5) == Z([6,2,3])
         assert ztype(5) + Z([1,2,3]) == Z([6,2,3])
         assert Z([1,2,3]) - ztype(5) == Z([-4,2,3])
@@ -526,8 +523,6 @@ def test_fmpz_mat():
     assert raises(lambda: a + c, ValueError)
     assert (a * 3).entries() == [3,6,9,12,15,18]
     assert (3 * a).entries() == [3,6,9,12,15,18]
-    assert (a * long(3)).entries() == [3,6,9,12,15,18]
-    assert (long(3) * a).entries() == [3,6,9,12,15,18]
     assert (a * flint.fmpz(3)).entries() == [3,6,9,12,15,18]
     assert (flint.fmpz(3) * a).entries() == [3,6,9,12,15,18]
     assert M.randrank(5,7,3,10).rank() == 3
@@ -756,7 +751,7 @@ def test_fmpq():
     assert 1 != Q(2)
     assert Q(1) != ()
     assert Q(1,2) != 1
-    assert Q(2,3) == Q(flint.fmpz(2),long(3))
+    assert Q(2,3) == Q(flint.fmpz(2),3)
     assert Q(-2,-4) == Q(1,2)
     assert Q("1") == Q(1)
     assert Q("1/2") == Q(1,2)
@@ -1481,8 +1476,6 @@ def test_nmod_mat():
     assert raises(lambda: a + c, ValueError)
     assert (a * 3).entries() == [G(x,17) for x in [3,6,9,12,15,18]]
     assert (3 * a).entries() == [G(x,17) for x in [3,6,9,12,15,18]]
-    assert (a * long(3)).entries() == [G(x,17) for x in [3,6,9,12,15,18]]
-    assert (long(3) * a).entries() == [G(x,17) for x in [3,6,9,12,15,18]]
     assert (a * flint.fmpz(3)).entries() == [G(x,17) for x in [3,6,9,12,15,18]]
     assert (flint.fmpz(3) * a).entries() == [G(x,17) for x in [3,6,9,12,15,18]]
     assert M(2,2,[1,1,2,2],17).rank() == 1

--- a/src/flint/types/acb_mat.pyx
+++ b/src/flint/types/acb_mat.pyx
@@ -25,12 +25,12 @@ cimport cython
 cdef acb_mat_coerce_operands(x, y):
     if isinstance(y, (fmpz_mat, fmpq_mat, arb_mat)):
         return x, acb_mat(y)
-    if isinstance(y, (int, long, float, complex, fmpz, fmpq, arb, acb)):
+    if isinstance(y, (int, float, complex, fmpz, fmpq, arb, acb)):
         return x, acb_mat(x.nrows(), x.ncols(), y)
     return NotImplemented, NotImplemented
 
 cdef acb_mat_coerce_scalar(x, y):
-    if isinstance(y, (int, long, float, complex, fmpz, fmpq, arb, acb)):
+    if isinstance(y, (int, float, complex, fmpz, fmpq, arb, acb)):
         return x, any_as_acb(y)
     return NotImplemented, NotImplemented
 
@@ -134,7 +134,7 @@ cdef class acb_mat(flint_mat):
         elif len(args) == 3:
             m, n, entries = args
             acb_mat_init(self.val, m, n)
-            if isinstance(entries, (int, long, float, complex, fmpz, fmpq, arb, acb)):
+            if isinstance(entries, (int, float, complex, fmpz, fmpq, arb, acb)):
                 c = entries
                 entries = [0] * (m * n)
                 for i in range(min(m,n)):

--- a/src/flint/types/acb_poly.pyx
+++ b/src/flint/types/acb_poly.pyx
@@ -20,7 +20,7 @@ from flint.flintlib.acb_poly cimport *
 cimport libc.stdlib
 
 cdef acb_poly_coerce_operands(x, y):
-    if isinstance(y, (int, long, float, complex, fmpz, fmpq, arb, acb, fmpz_poly, fmpq_poly, arb_poly)):
+    if isinstance(y, (int, float, complex, fmpz, fmpq, arb, acb, fmpz_poly, fmpq_poly, arb_poly)):
         return x, acb_poly(y)
     return NotImplemented, NotImplemented
 
@@ -328,7 +328,7 @@ cdef class acb_poly(flint_poly):
             u = acb.__new__(acb)
             acb_poly_evaluate((<acb>u).val, (<acb_poly>s).val, (<acb>t).val, getprec())
             return u
-        if isinstance(t, (int, long, float, complex, fmpz, fmpq, arb)):
+        if isinstance(t, (int, float, complex, fmpz, fmpq, arb)):
             return s(acb(t))
         if isinstance(t, (fmpz_poly, fmpq_poly, arb_poly)):
             return s(acb_poly(t))

--- a/src/flint/types/acb_series.pyx
+++ b/src/flint/types/acb_series.pyx
@@ -26,7 +26,7 @@ cimport cython
 cimport libc.stdlib
 
 cdef acb_series_coerce_operands(x, y):
-    if isinstance(y, (int, long, float, complex, fmpz, fmpz_poly, fmpz_series, fmpq, fmpq_poly, fmpq_series, arb, arb_poly, arb_series, acb, acb_poly)):
+    if isinstance(y, (int, float, complex, fmpz, fmpz_poly, fmpz_series, fmpq, fmpq_poly, fmpq_series, arb, arb_poly, arb_series, acb, acb_poly)):
         return x, acb_series(y)
     return NotImplemented, NotImplemented
 

--- a/src/flint/types/arb.pyx
+++ b/src/flint/types/arb.pyx
@@ -54,7 +54,7 @@ cdef arb_set_mpmath_mpf(arb_t x, obj):
         else:
             arb_indeterminate(x)
     else:
-        man = fmpz(long(man))
+        man = fmpz(int(man))
         exp = fmpz(exp)
 
         arb_set_fmpz(x, (<fmpz>man).val)
@@ -368,15 +368,15 @@ cdef class arb(flint_scalar):
             import mpmath
             mpmath_mpz = mpmath.libmp.MPZ
         except ImportError:
-            mpmath_mpz = long
+            mpmath_mpz = int
         if not self.is_finite():
             return (0, mpmath_mpz(0), -123, -1)
         man, exp = self.mid().man_exp()
-        man = mpmath_mpz(long(man))
+        man = mpmath_mpz(int(man))
         if man < 0:
-            return (1, -man, long(exp), man.bit_length())
+            return (1, -man, int(exp), man.bit_length())
         else:
-            return (0, man, long(exp), man.bit_length())
+            return (0, man, int(exp), man.bit_length())
 
     def repr(self):
         mid = self.mid()

--- a/src/flint/types/arb_mat.pyx
+++ b/src/flint/types/arb_mat.pyx
@@ -22,14 +22,14 @@ cimport cython
 cdef arb_mat_coerce_operands(x, y):
     if isinstance(y, (fmpz_mat, fmpq_mat)):
         return x, arb_mat(y)
-    if isinstance(y, (int, long, float, fmpz, fmpq, arb)):
+    if isinstance(y, (int, float, fmpz, fmpq, arb)):
         return x, arb_mat(x.nrows(), x.ncols(), y)
     if isinstance(y, (complex, acb)):
         return acb_mat(x), acb_mat(x.nrows(), x.ncols(), y)
     return NotImplemented, NotImplemented
 
 cdef arb_mat_coerce_scalar(x, y):
-    if isinstance(y, (int, long, float, fmpz, fmpq, arb)):
+    if isinstance(y, (int, float, fmpz, fmpq, arb)):
         return x, any_as_arb(y)
     if isinstance(y, (complex, acb)):
         return acb_mat(x), any_as_acb(y)
@@ -132,7 +132,7 @@ cdef class arb_mat(flint_mat):
         elif len(args) == 3:
             m, n, entries = args
             arb_mat_init(self.val, m, n)
-            if isinstance(entries, (int, long, float, fmpz, fmpq, arb)):
+            if isinstance(entries, (int, float, fmpz, fmpq, arb)):
                 c = entries
                 entries = [0] * (m * n)
                 for i in range(min(m,n)):

--- a/src/flint/types/arb_poly.pyx
+++ b/src/flint/types/arb_poly.pyx
@@ -18,7 +18,7 @@ cimport cython
 cimport libc.stdlib
 
 cdef arb_poly_coerce_operands(x, y):
-    if isinstance(y, (int, long, float, fmpz, fmpq, arb, fmpz_poly, fmpq_poly)):
+    if isinstance(y, (int, float, fmpz, fmpq, arb, fmpz_poly, fmpq_poly)):
         return x, arb_poly(y)
     if isinstance(y, (complex, acb)):
         return acb_poly(x), acb_poly(y)
@@ -330,7 +330,7 @@ cdef class arb_poly(flint_poly):
             u = acb.__new__(acb)
             arb_poly_evaluate_acb((<acb>u).val, (<arb_poly>s).val, (<acb>t).val, getprec())
             return u
-        if isinstance(t, (int, long, float, fmpz, fmpq)):
+        if isinstance(t, (int, float, fmpz, fmpq)):
             return s(arb(t))
         if isinstance(t, (fmpz_poly, fmpq_poly)):
             return s(arb_poly(t))

--- a/src/flint/types/arb_series.pyx
+++ b/src/flint/types/arb_series.pyx
@@ -22,7 +22,7 @@ from flint.flintlib.arb_hypgeom cimport *
 ctx = thectx
 
 cdef arb_series_coerce_operands(x, y):
-    if isinstance(y, (int, long, float, fmpz, fmpz_poly, fmpz_series, fmpq, fmpq_poly, fmpq_series, arb, arb_poly)):
+    if isinstance(y, (int, float, fmpz, fmpz_poly, fmpz_series, fmpq, fmpq_poly, fmpq_series, arb, arb_poly)):
         return x, arb_series(y)
     if isinstance(y, (complex, acb, acb_poly, acb_series)):
         return acb_series(x), acb_series(y)

--- a/src/flint/types/fmpq_series.pyx
+++ b/src/flint/types/fmpq_series.pyx
@@ -19,7 +19,7 @@ from flint.flintlib.fmpz cimport fmpz_is_zero,fmpz_set,fmpz_equal
 from flint.flintlib.fmpq_poly cimport *
 
 cdef fmpq_series_coerce_operands(x, y):
-    if isinstance(y, (int, long, fmpz, fmpz_poly, fmpz_series, fmpq, fmpq_poly)):
+    if isinstance(y, (int, fmpz, fmpz_poly, fmpz_series, fmpq, fmpq_poly)):
         return x, fmpq_series(y)
     #if isinstance(y, (nmod, nmod_poly, nmod_series)):
     #    return nmod_series(x), nmod_series(y)

--- a/src/flint/types/fmpz_series.pyx
+++ b/src/flint/types/fmpz_series.pyx
@@ -18,7 +18,7 @@ from flint.flintlib.fmpz cimport fmpz_is_zero, fmpz_is_pm1
 from flint.flintlib.fmpz_poly cimport *
 
 cdef fmpz_series_coerce_operands(x, y):
-    if isinstance(y, (int, long, fmpz, fmpz_poly)):
+    if isinstance(y, (int, fmpz, fmpz_poly)):
         return x, fmpz_series(y)
     if isinstance(y, (fmpq, fmpq_poly, fmpq_series)):
         return fmpq_series(x), fmpq_series(y)


### PR DESCRIPTION
Compatibility with Python is not needed any more and Cython 3.1.0 breaks references to long if languagelevel is set to 3 (https://github.com/cython/cython/pull/5830).