### PR TITLE
CI: build macos arm64 wheels in GitHub Actions

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -10,14 +10,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-13]
+        os: [ubuntu-20.04, windows-2019, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - uses: msys2/setup-msys2@v2
         with:
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-13]
+        os: [ubuntu-20.04, windows-2019, macos-13, macos-14]
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:


### PR DESCRIPTION
GitHub Actions now has macos arm64 runners. We can use them instead of Cirrus CI. Then all wheels will be built in GitHub and we can automate pushing them to PyPI.