### PR TITLE
build: add --local-flint to set rpath in dev build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/*
+build-install/*
 dist/*
 src/flint/**/*.c
 src/flint/*.html

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,16 @@ gmp_dep = dependency('gmp')
 mpfr_dep = dependency('mpfr')
 flint_dep = dependency('flint')
 
+# Add rpaths for a local build of flint found via pkgconfig
+#   https://github.com/mesonbuild/meson/issues/13046
+if get_option('add_flint_rpath')
+  flint_lib_dir = flint_dep.get_pkgconfig_variable('libdir')
+  add_project_link_arguments(
+    '-Wl,-rpath=' + flint_lib_dir,
+    language: 'c',
+  )
+endif
+
 # flint.pc was missing -lflint until Flint 3.1.0
 if flint_dep.version().version_compare('<3.1')
   flint_dep = cc.find_library('flint')

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,1 @@
+option('add_flint_rpath', type : 'boolean', value : false)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+cython
+spin
+meson
+meson-python
+pytest
+coverage
+pytest-cov

--- a/src/flint/flintlib/flint.pxd
+++ b/src/flint/flintlib/flint.pxd
@@ -36,13 +36,26 @@ cdef extern from "flint/fmpz.h":
 
 ctypedef slong fmpz_struct
 
+cdef extern from *:
+    """
+    /*
+     * Functions renamed in Flint 3.2.0
+     */
+    #if __FLINT_RELEASE < 30200 /* Flint < 3.2.0 */
+
+    #define flint_rand_init flint_randinit
+    #define flint_rand_clear flint_randclear
+
+    #endif
+    """
+
 cdef extern from "flint/flint.h":
     const char * FLINT_VERSION
     const int __FLINT_RELEASE
     const int FLINT_BITS
     ctypedef void * flint_rand_t
-    void flint_randinit(flint_rand_t state)
-    void flint_randclear(flint_rand_t state)
+    void flint_rand_init(flint_rand_t state)
+    void flint_rand_clear(flint_rand_t state)
     void flint_set_num_threads(long)
     long flint_get_num_threads()
     void flint_cleanup()

--- a/src/flint/pyflint.pyx
+++ b/src/flint/pyflint.pyx
@@ -9,6 +9,6 @@ cimport cython
 from flint.flint_base.flint_context cimport thectx
 
 cdef flint_rand_t global_random_state
-flint_randinit(global_random_state)
+flint_rand_init(global_random_state)
 
 ctx = thectx


### PR DESCRIPTION
This implements https://github.com/mesonbuild/meson/issues/13046#issuecomment-2099453043.

On Linux the current meson build needs `LD_LIBRARY_PATH` to be set when using a local build of flint. This adds a project option to install the rpaths and also customises spin's build command so that you can do:
```
spin build --local-flint=.local/lib/pkgconfig
```