### PR TITLE
maint: install wheel explicitly for cibuildwheel on Windows

### DIFF
--- a/bin/cibw_before_build_windows.sh
+++ b/bin/cibw_before_build_windows.sh
@@ -40,4 +40,4 @@ mv libpython${VER}.a libs
 #  Install build dependencies                     #
 ###################################################
 
-pip install cython numpy delvewheel
+pip install cython numpy delvewheel wheel


### PR DESCRIPTION
This is needed for cibuildwheel >= 2.18.0 since wheel is no longer installed implicitly.