### PR TITLE
fix: set --host=x86_64-* when building Flint and MPFR

### DIFF
--- a/bin/build_dependencies_unix.sh
+++ b/bin/build_dependencies_unix.sh
@@ -287,6 +287,7 @@ cd flint-$FLINTVER
     --disable-assembly\
     --disable-avx2\
     --disable-avx512\
+    --disable-arch\
     $FLINTARB_WITHGMP\
     --with-mpfr=$PREFIX\
     --disable-static\

--- a/bin/build_dependencies_unix.sh
+++ b/bin/build_dependencies_unix.sh
@@ -257,6 +257,7 @@ else
   tar xf mpfr-$MPFRVER.tar.gz
   cd mpfr-$MPFRVER
     ./configure --prefix=$PREFIX\
+      --host=$HOST_ARG\
       --with-gmp=$PREFIX\
       --enable-shared=yes\
       --enable-static=no
@@ -282,6 +283,7 @@ tar xf flint-$FLINTVER.tar.gz
 cd flint-$FLINTVER
   ./bootstrap.sh
   ./configure --prefix=$PREFIX\
+    --host=$HOST_ARG\
     $FLINTARB_WITHGMP\
     --with-mpfr=$PREFIX\
     --disable-static\

--- a/bin/build_dependencies_unix.sh
+++ b/bin/build_dependencies_unix.sh
@@ -284,6 +284,9 @@ cd flint-$FLINTVER
   ./bootstrap.sh
   ./configure --prefix=$PREFIX\
     --host=$HOST_ARG\
+    --disable-assembly\
+    --disable-avx2\
+    --disable-avx512\
     $FLINTARB_WITHGMP\
     --with-mpfr=$PREFIX\
     --disable-static\


### PR DESCRIPTION
This is needed when building portable wheels for PyPI upload.

Hopefully fixes gh-165