### PR TITLE
Make comparisons is_one, and is_zero consistent for polys

### DIFF
--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -1604,7 +1604,7 @@ def test_pickling():
 
 def test_fmpz_mod():
     from flint import fmpz_mod_ctx, fmpz, fmpz_mod
-    
+
     p_sml = 163
     p_med = 2**127 - 1
     p_big = 2**255 - 19
@@ -1754,7 +1754,7 @@ def test_fmpz_mod():
         assert raises(lambda: F_test(test_x) * "AAA", TypeError)
         assert raises(lambda: F_test(test_x) * F_other(test_x), ValueError)
 
-        # Exponentiation 
+        # Exponentiation
 
         assert F_test(0)**0 == pow(0, 0, test_mod)
         assert F_test(0)**1 == pow(0, 1, test_mod)
@@ -1804,7 +1804,7 @@ def test_fmpz_mod():
 
         assert fmpz(test_y) / F_test(test_x) == (test_y * pow(test_x, -1, test_mod)) % test_mod
         assert test_y / F_test(test_x) == (test_y * pow(test_x, -1, test_mod)) % test_mod
-            
+
 def test_fmpz_mod_dlog():
     from flint import fmpz, fmpz_mod_ctx
 
@@ -1826,7 +1826,7 @@ def test_fmpz_mod_dlog():
     F = fmpz_mod_ctx(163)
     g = F(2)
     a = g**123
-    
+
     assert 123 == g.discrete_log(a)
 
     a_int = pow(2, 123, 163)
@@ -1877,7 +1877,7 @@ def test_fmpz_mod_poly():
     assert repr(R3) == "fmpz_mod_poly_ctx(13)"
 
     assert R1.modulus() == 11
-    
+
     assert R1.is_prime()
     assert R1.zero() == 0
     assert R1.one() == 1
@@ -1946,7 +1946,7 @@ def test_fmpz_mod_poly():
     assert str(f) == "8*x^3 + 7*x^2 + 6*x + 7"
 
     # TODO: currently repr does pretty printing
-    # just like str, we should address this. Mainly, 
+    # just like str, we should address this. Mainly,
     # the issue is we want nice `repr` behaviour in
     # interactive shells, which currently is why this
     # choice has been made
@@ -1992,7 +1992,7 @@ def test_fmpz_mod_poly():
     F_sml = fmpz_mod_ctx(p_sml)
     F_med = fmpz_mod_ctx(p_med)
     F_big = fmpz_mod_ctx(p_big)
-    
+
     R_sml = fmpz_mod_poly_ctx(F_sml)
     R_med = fmpz_mod_poly_ctx(F_med)
     R_big = fmpz_mod_poly_ctx(F_big)
@@ -2003,14 +2003,14 @@ def test_fmpz_mod_poly():
     f_bad = R_cmp([2,2,2,2,2])
 
     for (F_test, R_test) in [(F_sml, R_sml), (F_med, R_med), (F_big, R_big)]:
-        
+
         f = R_test([-1,-2])
         g = R_test([-3,-4])
 
         # pos, neg
         assert f is +f
         assert -f == R_test([1,2])
-        
+
         # add
         assert raises(lambda: f + f_cmp, ValueError)
         assert raises(lambda: f + "AAA", TypeError)
@@ -2063,7 +2063,7 @@ def test_fmpz_mod_poly():
         assert raises(lambda: f / "AAA", TypeError)
         assert raises(lambda: f / 0, ZeroDivisionError)
         assert raises(lambda: f_cmp / 2, ZeroDivisionError)
-    
+
         assert (f + f) / 2  ==  f
         assert (f + f) / fmpz(2)  ==  f
         assert (f + f) / F_test(2)  ==  f
@@ -2077,7 +2077,7 @@ def test_fmpz_mod_poly():
         assert (f + f) // 2  ==  f
         assert (f + f) // fmpz(2)  ==  f
         assert (f + f) // F_test(2)  ==  f
-        assert 2 // R_test(2) == 1        
+        assert 2 // R_test(2) == 1
         assert (f + 1) // f == 1
 
         # pow
@@ -2171,7 +2171,7 @@ def test_fmpz_mod_poly():
         f1 = R_test([-3, 1])
         f2 = R_test([-5, 1])
         assert f1.resultant(f2) == (3 - 5)
-        assert raises(lambda: f.resultant("AAA"), TypeError)        
+        assert raises(lambda: f.resultant("AAA"), TypeError)
 
         # sqrt
         f1 = R_test.random_element(irreducible=True)
@@ -2428,14 +2428,14 @@ def _all_polys():
         (flint.fmpz_poly, flint.fmpz, False),
         (flint.fmpq_poly, flint.fmpq, True),
         (lambda *a: flint.nmod_poly(*a, 17), lambda x: flint.nmod(x, 17), True),
-        (lambda *a: flint.fmpz_mod_poly(*a, flint.fmpz_mod_poly_ctx(163)), 
-         lambda x: flint.fmpz_mod(x, flint.fmpz_mod_ctx(163)), 
+        (lambda *a: flint.fmpz_mod_poly(*a, flint.fmpz_mod_poly_ctx(163)),
+         lambda x: flint.fmpz_mod(x, flint.fmpz_mod_ctx(163)),
          True),
-        (lambda *a: flint.fmpz_mod_poly(*a, flint.fmpz_mod_poly_ctx(2**127 - 1)), 
-         lambda x: flint.fmpz_mod(x, flint.fmpz_mod_ctx(2**127 - 1)), 
+        (lambda *a: flint.fmpz_mod_poly(*a, flint.fmpz_mod_poly_ctx(2**127 - 1)),
+         lambda x: flint.fmpz_mod(x, flint.fmpz_mod_ctx(2**127 - 1)),
          True),
-        (lambda *a: flint.fmpz_mod_poly(*a, flint.fmpz_mod_poly_ctx(2**255 - 19)), 
-         lambda x: flint.fmpz_mod(x, flint.fmpz_mod_ctx(2**255 - 19)), 
+        (lambda *a: flint.fmpz_mod_poly(*a, flint.fmpz_mod_poly_ctx(2**255 - 19)),
+         lambda x: flint.fmpz_mod(x, flint.fmpz_mod_ctx(2**255 - 19)),
          True),
     ]
 
@@ -2466,6 +2466,28 @@ def test_polys():
         assert (P([1]) != P([1])) is False
         assert (P([1]) == P([2])) is False
         assert (P([1]) != P([2])) is True
+
+        assert (P([1]) == 1) is True
+        assert (P([1]) != 1) is False
+        assert (P([1]) == 2) is False
+        assert (P([1]) != 2) is True
+
+        assert (1 == P([1])) is True
+        assert (1 != P([1])) is False
+        assert (2 == P([1])) is False
+        assert (2 != P([1])) is True
+
+        s1, s2 = S(1), S(2)
+
+        assert (P([s1]) == s1) is True
+        assert (P([s1]) != s1) is False
+        assert (P([s1]) == s2) is False
+        assert (P([s1]) != s2) is True
+
+        assert (s1 == P([s1])) is True
+        assert (s1 != P([s1])) is False
+        assert (s1 == P([s2])) is False
+        assert (s1 != P([s2])) is True
 
         assert (P([1]) == None) is False
         assert (P([1]) != None) is True
@@ -2500,12 +2522,17 @@ def test_polys():
         assert raises(lambda: setbad(p, -1, 1), ValueError)
 
         for v in [], [1], [1, 2]:
-            if P == flint.fmpz_poly:
+            p = P(v)
+            if type(p) == flint.fmpz_poly:
                 assert P(v).repr() == f'fmpz_poly({v!r})'
-            elif P == flint.fmpq_poly:
+            elif type(p) == flint.fmpq_poly:
                 assert P(v).repr() == f'fmpq_poly({v!r})'
-            elif P == flint.nmod_poly:
+            elif type(p) == flint.nmod_poly:
                 assert P(v).repr() == f'nmod_poly({v!r}, 17)'
+            elif type(p) == flint.fmpz_mod_poly:
+                pass # fmpz_mod_poly does not have .repr() ...
+            else:
+                assert False
 
         assert repr(P([])) == '0'
         assert repr(P([1])) == '1'
@@ -2520,6 +2547,12 @@ def test_polys():
 
         assert bool(P([])) is False
         assert bool(P([1])) is True
+
+        assert P([]).is_zero() is True
+        assert P([1]).is_zero() is False
+
+        assert P([]).is_one() is False
+        assert P([1]).is_one() is True
 
         assert +P([1, 2, 3]) == P([1, 2, 3])
         assert -P([1, 2, 3]) == P([-1, -2, -3])
@@ -2600,7 +2633,7 @@ def test_polys():
         assert P([1, 1]) ** 2 == P([1, 2, 1])
         assert raises(lambda: P([1, 1]) ** -1, ValueError)
         assert raises(lambda: P([1, 1]) ** None, TypeError)
-        
+
         # # XXX: Not sure what this should do in general:
         assert raises(lambda: pow(P([1, 1]), 2, 3), NotImplementedError)
 
@@ -2824,6 +2857,12 @@ def test_mpolys():
 
         assert bool(P(ctx=ctx)) is False
         assert bool(P(1, ctx=ctx)) is True
+
+        assert P(ctx=ctx).is_zero() is True
+        assert P(1, ctx=ctx).is_zero() is False
+
+        assert P(ctx=ctx).is_one() is False
+        assert P(1, ctx=ctx).is_one() is True
 
         assert +quick_poly() \
             == quick_poly()

--- a/src/flint/types/acb_mat.pyx
+++ b/src/flint/types/acb_mat.pyx
@@ -150,7 +150,7 @@ cdef class acb_mat(flint_mat):
         else:
             raise ValueError("acb_mat: expected 1-3 arguments")
 
-    def __nonzero__(self):
+    def __bool__(self):
         raise NotImplementedError
 
     cpdef long nrows(s):

--- a/src/flint/types/arb_mat.pyx
+++ b/src/flint/types/arb_mat.pyx
@@ -148,7 +148,7 @@ cdef class arb_mat(flint_mat):
         else:
             raise ValueError("arb_mat: expected 1-3 arguments")
 
-    def __nonzero__(self):
+    def __bool__(self):
         raise NotImplementedError
 
     cpdef long nrows(s):

--- a/src/flint/types/fmpq.pyx
+++ b/src/flint/types/fmpq.pyx
@@ -186,7 +186,7 @@ cdef class fmpq(flint_scalar):
     def __trunc__(self):
         return self.trunc()
 
-    def __nonzero__(self):
+    def __bool__(self):
         return not fmpq_is_zero(self.val)
 
     def __round__(self, ndigits=None):

--- a/src/flint/types/fmpq_mat.pyx
+++ b/src/flint/types/fmpq_mat.pyx
@@ -92,7 +92,7 @@ cdef class fmpq_mat(flint_mat):
         else:
             raise TypeError("fmpq_mat: expected 1-3 arguments")
 
-    def __nonzero__(self):
+    def __bool__(self):
         return not fmpq_mat_is_zero(self.val)
 
     def __richcmp__(s, t, int op):

--- a/src/flint/types/fmpq_mpoly.pyx
+++ b/src/flint/types/fmpq_mpoly.pyx
@@ -243,6 +243,12 @@ cdef class fmpq_mpoly(flint_mpoly):
     def __bool__(self):
         return not fmpq_mpoly_is_zero(self.val, self.ctx.val)
 
+    def is_zero(self):
+        return <bint>fmpq_mpoly_is_zero(self.val, self.ctx.val)
+
+    def is_one(self):
+        return <bint>fmpq_mpoly_is_one(self.val, self.ctx.val)
+
     def __richcmp__(self, other, int op):
         if not (op == Py_EQ or op == Py_NE):
             return NotImplemented
@@ -781,9 +787,6 @@ cdef class fmpq_mpoly(flint_mpoly):
             True
         """
         return self.ctx
-
-    def is_one(self):
-        return fmpq_mpoly_is_one(self.val, self.ctx.val)
 
     def coefficient(self, slong i):
         """

--- a/src/flint/types/fmpq_poly.pyx
+++ b/src/flint/types/fmpq_poly.pyx
@@ -167,8 +167,14 @@ cdef class fmpq_poly(flint_poly):
         else:
             return "fmpq_poly(%s, %s)" % ([int(c) for c in n.coeffs()], d)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return not fmpq_poly_is_zero(self.val)
+
+    def is_zero(self):
+        return <bint>fmpq_poly_is_zero(self.val)
+
+    def is_one(self):
+        return <bint>fmpq_poly_is_one(self.val)
 
     def __call__(self, other):
         t = any_as_fmpz(other)

--- a/src/flint/types/fmpz.pyx
+++ b/src/flint/types/fmpz.pyx
@@ -168,7 +168,7 @@ cdef class fmpz(flint_scalar):
     def repr(self):
         return "fmpz(%s)" % self.str()
 
-    def __nonzero__(self):
+    def __bool__(self):
         return not fmpz_is_zero(self.val)
 
     def __pos__(self):

--- a/src/flint/types/fmpz_mat.pyx
+++ b/src/flint/types/fmpz_mat.pyx
@@ -131,7 +131,7 @@ cdef class fmpz_mat(flint_mat):
         else:
             raise TypeError("fmpz_mat: expected 1-3 arguments")
 
-    def __nonzero__(self):
+    def __bool__(self):
         return not fmpz_mat_is_zero(self.val)
 
     def __richcmp__(fmpz_mat s, t, int op):

--- a/src/flint/types/fmpz_mod_mat.pyx
+++ b/src/flint/types/fmpz_mod_mat.pyx
@@ -303,7 +303,7 @@ cdef class fmpz_mod_mat(flint_mat):
         e = self.ctx.any_as_fmpz_mod(value)
         self._setitem(i, j, e.val)
 
-    def __nonzero__(self):
+    def __bool__(self):
         """Return ``True`` if the matrix has any nonzero entries."""
         cdef bint zero
         zero = compat_fmpz_mod_mat_is_zero(self.val, self.ctx.val)

--- a/src/flint/types/fmpz_mpoly.pyx
+++ b/src/flint/types/fmpz_mpoly.pyx
@@ -223,6 +223,12 @@ cdef class fmpz_mpoly(flint_mpoly):
     def __bool__(self):
         return not fmpz_mpoly_is_zero(self.val, self.ctx.val)
 
+    def is_zero(self):
+        return <bint>fmpz_mpoly_is_zero(self.val, self.ctx.val)
+
+    def is_one(self):
+        return <bint>fmpz_mpoly_is_one(self.val, self.ctx.val)
+
     def __richcmp__(self, other, int op):
         if not (op == Py_EQ or op == Py_NE):
             return NotImplemented
@@ -763,9 +769,6 @@ cdef class fmpz_mpoly(flint_mpoly):
             True
         """
         return self.ctx
-
-    def is_one(self):
-        return fmpz_mpoly_is_one(self.val, self.ctx.val)
 
     def coefficient(self, slong i):
         """

--- a/src/flint/types/fmpz_poly.pyx
+++ b/src/flint/types/fmpz_poly.pyx
@@ -137,8 +137,14 @@ cdef class fmpz_poly(flint_poly):
     def repr(self):
         return "fmpz_poly([%s])" % (", ".join(map(str, self.coeffs())))
 
-    def __nonzero__(self):
+    def __bool__(self):
         return not fmpz_poly_is_zero(self.val)
+
+    def is_zero(self):
+        return <bint>fmpz_poly_is_zero(self.val)
+
+    def is_one(self):
+        return <bint>fmpz_poly_is_one(self.val)
 
     def __call__(self, other):
         t = any_as_fmpz(other)

--- a/src/flint/types/nmod.pyx
+++ b/src/flint/types/nmod.pyx
@@ -89,7 +89,7 @@ cdef class nmod(flint_scalar):
     def __hash__(self):
         return hash((int(self.val), self.modulus))
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self.val != 0
 
     def __pos__(self):

--- a/src/flint/types/nmod_mat.pyx
+++ b/src/flint/types/nmod_mat.pyx
@@ -136,7 +136,7 @@ cdef class nmod_mat(flint_mat):
         else:
             raise TypeError("nmod_mat: expected 1-3 arguments plus modulus")
 
-    def __nonzero__(self):
+    def __bool__(self):
         return not nmod_mat_is_zero(self.val)
 
     def __richcmp__(s, t, int op):

--- a/src/flint/types/nmod_poly.pyx
+++ b/src/flint/types/nmod_poly.pyx
@@ -117,7 +117,7 @@ cdef class nmod_poly(flint_poly):
         cdef mp_limb_t v
         cdef bint res
         if op != 2 and op != 3:
-            raise TypeError("nmod_polyss cannot be ordered")
+            raise TypeError("nmod_polys cannot be ordered")
         if typecheck(s, nmod_poly) and typecheck(t, nmod_poly):
             if (<nmod_poly>s).val.mod.n != (<nmod_poly>t).val.mod.n:
                 res = False
@@ -127,6 +127,22 @@ cdef class nmod_poly(flint_poly):
                 return res
             if op == 3:
                 return not res
+        else:
+            if not typecheck(s, nmod_poly):
+                s, t = t, s
+            try:
+                t = nmod_poly([t], (<nmod_poly>s).val.mod.n)
+            except TypeError:
+                pass
+            if typecheck(s, nmod_poly) and typecheck(t, nmod_poly):
+                if (<nmod_poly>s).val.mod.n != (<nmod_poly>t).val.mod.n:
+                    res = False
+                else:
+                    res = nmod_poly_equal((<nmod_poly>s).val, (<nmod_poly>t).val)
+                if op == 2:
+                    return res
+                if op == 3:
+                    return not res
         return NotImplemented
 
     def __iter__(self):
@@ -166,8 +182,14 @@ cdef class nmod_poly(flint_poly):
         else:
             raise TypeError("cannot set element of type %s" % type(x))
 
-    def __nonzero__(self):
+    def __bool__(self):
         return not nmod_poly_is_zero(self.val)
+
+    def is_zero(self):
+        return <bint>nmod_poly_is_zero(self.val)
+
+    def is_one(self):
+        return <bint>nmod_poly_is_one(self.val)
 
     def __call__(self, other):
         cdef mp_limb_t c


### PR DESCRIPTION
nmod_poly previously compared unequal to an integer e.g.
```
  >>> nmod_poly([1], 3) == 1
  False
```
This was inconsistent with all other poly types and also with nmod. The change here makes it so that `nmod_poly` can compare equal with anything that can be coerced by the nmod constructor.

We currently have:
```
  >>> nmod(1, 3) == fmpz(1)
  False

  >>> nmod(1, 3) == 1
  True
```
So an exception is made here for int but comparison with fmpz is not allowed. The change here does the same thing for nmod_poly. It will compare unequal to fmpz_poly but will compare equal to an int or an nmod with the same modulus.

Also renamed all `__nonzero__` methods to `__bool__` (Python 3 vs 2)

Also added `is_one` and `is_zero` to almost all `*_poly` and `*_mpoly` types because this was inconsistent before.

The two poly types that I didn't add `is_one` and `is_zero` to are `arb_poly` and `acb_poly`. I was unsure what the expected behaviour there should be...

Currently `fmpz_mod` has both `is_one` and `is_zero` but all other scalar types do not. I'm not sure whether it makes sense to add them just for overall consistency. No matrix types have `is_zero` or `is_one` although there are corresponding Flint functions for this.