### PR TITLE
fix(nmod): Add nmod_ctx to store is_prime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,11 @@ classifiers = [
 file = "README.md"
 content-type = "text/markdown"
 
+[tool.meson-python.args]
+setup = [
+    "-Dadd_flint_rpath=true",
+]
+
 [tool.spin]
 package = "flint"
 

--- a/src/flint/types/nmod.pxd
+++ b/src/flint/types/nmod.pxd
@@ -2,8 +2,16 @@ from flint.flint_base.flint_base cimport flint_scalar
 from flint.flintlib.flint cimport mp_limb_t
 from flint.flintlib.nmod cimport nmod_t
 
-cdef int any_as_nmod(mp_limb_t * val, obj, nmod_t mod) except -1
+#cdef int any_as_nmod(mp_limb_t * val, obj, nmod_t mod) except -1
+cdef nmod_ctx any_as_nmod_ctx(obj)
+
+cdef class nmod_ctx:
+    cdef nmod_t mod
+    cdef bint _is_prime
+
+    cdef int any_as_nmod(self, mp_limb_t * val, obj) except -1
+    cdef nmod _new(self, mp_limb_t * val)
 
 cdef class nmod(flint_scalar):
     cdef mp_limb_t val
-    cdef nmod_t mod
+    cdef nmod_ctx ctx

--- a/src/flint/types/nmod.pyx
+++ b/src/flint/types/nmod.pyx
@@ -12,31 +12,142 @@ from flint.flintlib.nmod_vec cimport *
 from flint.flintlib.fmpz cimport fmpz_fdiv_ui, fmpz_init, fmpz_clear
 from flint.flintlib.fmpz cimport fmpz_set_ui, fmpz_get_ui
 from flint.flintlib.fmpq cimport fmpq_mod_fmpz
-from flint.flintlib.ulong_extras cimport n_gcdinv
+from flint.flintlib.ulong_extras cimport n_gcdinv, n_is_prime
 
-cdef int any_as_nmod(mp_limb_t * val, obj, nmod_t mod) except -1:
-    cdef int success
-    cdef fmpz_t t
-    if typecheck(obj, nmod):
-        if (<nmod>obj).mod.n != mod.n:
-            raise ValueError("cannot coerce integers mod n with different n")
-        val[0] = (<nmod>obj).val
-        return 1
-    z = any_as_fmpz(obj)
-    if z is not NotImplemented:
-        val[0] = fmpz_fdiv_ui((<fmpz>z).val, mod.n)
-        return 1
-    q = any_as_fmpq(obj)
-    if q is not NotImplemented:
-        fmpz_init(t)
-        fmpz_set_ui(t, mod.n)
-        success = fmpq_mod_fmpz(t, (<fmpq>q).val, t)
-        val[0] = fmpz_get_ui(t)
-        fmpz_clear(t)
-        if not success:
-            raise ZeroDivisionError("%s does not exist mod %i!" % (q, mod.n))
-        return 1
-    return 0
+
+#cdef int any_as_nmod(mp_limb_t * val, obj, nmod_t mod) except -1:
+#    return mod.ctx.any_as_nmod(val, obj)
+
+
+_nmod_ctx_cache = {}
+
+
+cdef nmod_ctx any_as_nmod_ctx(obj):
+    """Convert an int to an nmod_ctx."""
+    if typecheck(obj, nmod_ctx):
+        return obj
+    if typecheck(obj, int):
+        ctx = _nmod_ctx_cache.get(obj)
+        if ctx is None:
+            ctx = nmod_ctx(obj)
+            _nmod_ctx_cache[obj] = ctx
+        return ctx
+    return NotImplemented
+
+
+cdef class nmod_ctx:
+    """
+    Context object for creating :class:`~.nmod` initalised 
+    with modulus :math:`N`.
+
+        >>> nmod_ctx(17)
+        nmod_ctx(17)
+
+    """
+    def __init__(self, mod):
+        cdef mp_limb_t m
+        m = mod
+        nmod_init(&self.mod, m)
+        self._is_prime = n_is_prime(m)
+
+    cdef int any_as_nmod(self, mp_limb_t * val, obj) except -1:
+        """Convert an object to an nmod element."""
+        cdef int success
+        cdef fmpz_t t
+        if typecheck(obj, nmod):
+            if (<nmod>obj).ctx != self:
+                raise ValueError("cannot coerce integers mod n with different n")
+            val[0] = (<nmod>obj).val
+            return 1
+        z = any_as_fmpz(obj)
+        if z is not NotImplemented:
+            val[0] = fmpz_fdiv_ui((<fmpz>z).val, self.mod.n)
+            return 1
+        q = any_as_fmpq(obj)
+        if q is not NotImplemented:
+            fmpz_init(t)
+            fmpz_set_ui(t, self.mod.n)
+            success = fmpq_mod_fmpz(t, (<fmpq>q).val, t)
+            val[0] = fmpz_get_ui(t)
+            fmpz_clear(t)
+            if not success:
+                raise ZeroDivisionError("%s does not exist mod %i!" % (q, self.mod.n))
+            return 1
+        return 0
+
+    def modulus(self):
+        """Get the modulus of the context.
+
+        >>> ctx = nmod_ctx(17)
+        >>> ctx.modulus()
+        17
+
+        """
+        return fmpz(self.mod)
+
+    def is_prime(self):
+        """Check if the modulus is prime.
+
+        >>> ctx = nmod_ctx(17)
+        >>> ctx.is_prime()
+        True
+
+        """
+        return self._is_prime
+
+    def zero(self):
+        """Return the zero element of the context.
+
+        >>> ctx = nmod_ctx(17)
+        >>> ctx.zero()
+        0
+
+        """
+        return self(0)
+
+    def one(self):
+        """Return the one element of the context.
+
+        >>> ctx = nmod_ctx(17)
+        >>> ctx.one()
+        1
+
+        """
+        return self(1)
+
+    def __hash__(self):
+        return hash(self.mod)
+
+    def __eq__(self, other):
+        if not typecheck(other, nmod_ctx):
+            return NotImplemented
+        else:
+            return self.mod == other.mod
+
+    def __str__(self):
+        return f"Context for nmod with modulus: {self.modulus()}"
+
+    def __repr__(self):
+        return f"nmod_ctx({self.modulus()})"
+
+    cdef nmod _new(self, mp_limb_t * val):
+        cdef nmod r = nmod.__new__(nmod)
+        r.val = val[0]
+        r.ctx = self
+        return r
+
+    def __call__(self, val):
+        """Create an nmod element from an integer.
+
+        >>> ctx = nmod_ctx(17)
+        >>> ctx(10)
+        10
+
+        """
+        cdef mp_limb_t v
+        v = val
+        return self._new(&v)
+
 
 cdef class nmod(flint_scalar):
     """
@@ -46,16 +157,15 @@ cdef class nmod(flint_scalar):
         3
 
     """
-
     def __init__(self, val, mod):
-        cdef mp_limb_t m
-        m = mod
-        nmod_init(&self.mod, m)
-        if not any_as_nmod(&self.val, val, self.mod):
+        ctx = any_as_nmod_ctx(mod)
+        if ctx is NotImplemented:
+            raise TypeError("Invalid context/modulus for nmod: %s" % mod)
+        if not ctx.any_as_nmod(&self.val, val):
             raise TypeError("cannot create nmod from object of type %s" % type(val))
 
     def repr(self):
-        return "nmod(%s, %s)" % (self.val, self.mod.n)
+        return "nmod(%s, %s)" % (self.val, self.ctx.mod.n)
 
     def str(self):
         return str(int(self.val))
@@ -64,7 +174,7 @@ cdef class nmod(flint_scalar):
         return int(self.val)
 
     def modulus(self):
-        return self.mod.n
+        return self.ctx.mod.n
 
     def __richcmp__(s, t, int op):
         cdef mp_limb_t v
@@ -73,13 +183,13 @@ cdef class nmod(flint_scalar):
             raise TypeError("nmods cannot be ordered")
         if typecheck(s, nmod) and typecheck(t, nmod):
             res = ((<nmod>s).val == (<nmod>t).val) and \
-                  ((<nmod>s).mod.n == (<nmod>t).mod.n)
+                  ((<nmod>s).ctx.mod.n == (<nmod>t).ctx.mod.n)
             if op == 2:
                 return res
             else:
                 return not res
         elif typecheck(s, nmod) and typecheck(t, int):
-            res = s.val == (t % s.mod.n)
+            res = s.val == (t % s.ctx.mod.n)
             if op == 2:
                 return res
             else:
@@ -97,100 +207,108 @@ cdef class nmod(flint_scalar):
 
     def __neg__(self):
         cdef nmod r = nmod.__new__(nmod)
-        r.mod = self.mod
-        r.val = nmod_neg(self.val, self.mod)
+        r.ctx = self.ctx
+        r.val = nmod_neg(self.val, self.ctx.mod)
         return r
 
     def __add__(s, t):
-        cdef nmod r
+        cdef nmod r, s2
         cdef mp_limb_t val
-        if any_as_nmod(&val, t, (<nmod>s).mod):
+        s2 = s
+        if s2.ctx.any_as_nmod(&val, t):
             r = nmod.__new__(nmod)
-            r.mod = (<nmod>s).mod
-            r.val = nmod_add(val, (<nmod>s).val, r.mod)
+            r.ctx = s2.ctx
+            r.val = nmod_add(val, s2.val, s2.ctx.mod)
             return r
         return NotImplemented
 
     def __radd__(s, t):
-        cdef nmod r
+        cdef nmod r, s2
         cdef mp_limb_t val
-        if any_as_nmod(&val, t, (<nmod>s).mod):
+        s2 = s
+        if s2.ctx.any_as_nmod(&val, t):
             r = nmod.__new__(nmod)
-            r.mod = (<nmod>s).mod
-            r.val = nmod_add((<nmod>s).val, val, r.mod)
+            r.ctx = s2.ctx
+            r.val = nmod_add(s2.val, val, s2.ctx.mod)
             return r
         return NotImplemented
 
     def __sub__(s, t):
-        cdef nmod r
+        cdef nmod r, s2
         cdef mp_limb_t val
-        if any_as_nmod(&val, t, (<nmod>s).mod):
+        s2 = s
+        if s2.ctx.any_as_nmod(&val, t):
             r = nmod.__new__(nmod)
-            r.mod = (<nmod>s).mod
-            r.val = nmod_sub((<nmod>s).val, val, r.mod)
+            r.ctx = s2.ctx
+            r.val = nmod_sub(s2.val, val, s2.ctx.mod)
             return r
         return NotImplemented
 
     def __rsub__(s, t):
         cdef nmod r
         cdef mp_limb_t val
-        if any_as_nmod(&val, t, (<nmod>s).mod):
+        s2 = s
+        if s2.ctx.any_as_nmod(&val, t):
             r = nmod.__new__(nmod)
-            r.mod = (<nmod>s).mod
-            r.val = nmod_sub(val, (<nmod>s).val, r.mod)
+            r.ctx = s2.ctx
+            r.val = nmod_sub(val, s2.val, s2.ctx.mod)
             return r
         return NotImplemented
 
     def __mul__(s, t):
-        cdef nmod r
+        cdef nmod r, s2
         cdef mp_limb_t val
-        if any_as_nmod(&val, t, (<nmod>s).mod):
+        s2 = s
+        if s2.ctx.any_as_nmod(&val, t):
             r = nmod.__new__(nmod)
-            r.mod = (<nmod>s).mod
-            r.val = nmod_mul(val, (<nmod>s).val, r.mod)
+            r.ctx = s2.ctx
+            r.val = nmod_mul(val, s2.val, s2.ctx.mod)
             return r
         return NotImplemented
 
     def __rmul__(s, t):
-        cdef nmod r
+        cdef nmod r, s2
         cdef mp_limb_t val
-        if any_as_nmod(&val, t, (<nmod>s).mod):
+        s2 = s
+        if s2.ctx.any_as_nmod(&val, t):
             r = nmod.__new__(nmod)
-            r.mod = (<nmod>s).mod
-            r.val = nmod_mul((<nmod>s).val, val, r.mod)
+            r.ctx = s2.ctx
+            r.val = nmod_mul(s2.val, val, s2.ctx.mod)
             return r
         return NotImplemented
 
     @staticmethod
     def _div_(s, t):
-        cdef nmod r
+        cdef nmod r, s2, t2
         cdef mp_limb_t sval, tval, x
-        cdef nmod_t mod
+        cdef nmod_ctx ctx
         cdef ulong tinvval
 
         if typecheck(s, nmod):
-            mod = (<nmod>s).mod
-            sval = (<nmod>s).val
-            if not any_as_nmod(&tval, t, mod):
+            s2 = s
+            ctx = s2.ctx
+            sval = s2.val
+            if not ctx.any_as_nmod(&tval, t):
                 return NotImplemented
         else:
-            mod = (<nmod>t).mod
-            tval = (<nmod>t).val
-            if not any_as_nmod(&sval, s, mod):
+            t2 = t
+            ctx = t2.ctx
+            tval = t2.val
+            if not ctx.any_as_nmod(&sval, s):
                 return NotImplemented
 
         if tval == 0:
-            raise ZeroDivisionError("%s is not invertible mod %s" % (tval, mod.n))
+            raise ZeroDivisionError("%s is not invertible mod %s" % (tval, ctx.mod.n))
         if not s:
             return s
 
-        g = n_gcdinv(&tinvval, <ulong>tval, <ulong>mod.n)
+        g = n_gcdinv(&tinvval, <ulong>tval, <ulong>ctx.mod.n)
         if g != 1:
-            raise ZeroDivisionError("%s is not invertible mod %s" % (tval, mod.n))
+            raise ZeroDivisionError("%s is not invertible mod %s" % (tval, ctx.mod.n))
 
         r = nmod.__new__(nmod)
-        r.mod = mod
-        r.val = nmod_mul(sval, <mp_limb_t>tinvval, mod)
+        r.ctx = ctx
+        r.val = nmod_mul(sval, <mp_limb_t>tinvval, ctx.mod)
         return r
 
     def __truediv__(s, t):
@@ -200,19 +318,22 @@ cdef class nmod(flint_scalar):
         return nmod._div_(t, s)
 
     def __invert__(self):
-        cdef nmod r
+        cdef nmod r, s
+        cdef nmod_ctx ctx
         cdef ulong g, inv, sval
-        sval = <ulong>(<nmod>self).val
-        g = n_gcdinv(&inv, sval, self.mod.n)
+        s = self
+        ctx = s.ctx
+        sval = <ulong>s.val
+        g = n_gcdinv(&inv, sval, ctx.mod.n)
         if g != 1:
-            raise ZeroDivisionError("%s is not invertible mod %s" % (sval, self.mod.n))
+            raise ZeroDivisionError("%s is not invertible mod %s" % (sval, ctx.mod.n))
         r = nmod.__new__(nmod)
-        r.mod = self.mod
+        r.ctx = ctx
         r.val = <mp_limb_t>inv
         return r
 
     def __pow__(self, exp, modulus=None):
-        cdef nmod r
+        cdef nmod r, s
         cdef mp_limb_t rval, mod
         cdef ulong g, rinv
 
@@ -223,8 +344,10 @@ cdef class nmod(flint_scalar):
         if e is NotImplemented:
             return NotImplemented
 
-        rval = (<nmod>self).val
-        mod = (<nmod>self).mod.n
+        s = self
+        ctx = s.ctx
+        rval = s.val
+        mod = ctx.mod.n
 
         # XXX: It is not clear that it is necessary to special case negative
         # exponents here. The nmod_pow_fmpz function seems to handle this fine
@@ -237,6 +360,6 @@ cdef class nmod(flint_scalar):
             e = -e
 
         r = nmod.__new__(nmod)
-        r.mod = self.mod
-        r.val = nmod_pow_fmpz(rval, (<fmpz>e).val, self.mod)
+        r.ctx = ctx
+        r.val = nmod_pow_fmpz(rval, (<fmpz>e).val, ctx.mod)
         return r

--- a/src/flint/types/nmod_poly.pyx
+++ b/src/flint/types/nmod_poly.pyx
@@ -4,7 +4,7 @@ from flint.utils.typecheck cimport typecheck
 from flint.types.fmpz cimport fmpz, any_as_fmpz
 from flint.types.fmpz_poly cimport any_as_fmpz_poly
 from flint.types.fmpz_poly cimport fmpz_poly
-from flint.types.nmod cimport any_as_nmod
+from flint.types.nmod cimport any_as_nmod_ctx
 from flint.types.nmod cimport nmod
 
 from flint.flintlib.nmod_vec cimport *


### PR DESCRIPTION
Work in progress...

Have nmod use a context object so that we can store the additional information that the modulus is prime to avoid operations that might fail for non-prime modulus (gh-124).