### PR TITLE
Add CPython 3.13 and set dependency version constraints

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -150,7 +150,10 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install libflint-dev
       # The versions here should be kept in sync with pyproject.toml.
-      - run: 'pip install cython==3.0 meson-python==0.13'
+      # Not sure if ninja should be listed as a requirement in pyproject.toml
+      # as with newer meson-python it does not seem to be needed but this CI
+      # job would fail without it being installed explicitly here...
+      - run: 'pip install cython==3.0 meson-python'
       - run: pip install --no-build-isolation .
       - run: python -m flint.test --verbose
 

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
       matrix:
         # Supported versions and latest git
-        flint-tag: ['v3.0.0', 'v3.0.1', 'v3.1.0', 'v3.1.1', 'v3.1.2', 'main']
+        flint-tag: ['v3.0.0', 'v3.0.1', 'v3.1.0', 'v3.1.1', 'v3.1.2']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -189,6 +189,24 @@ jobs:
           python-version: '3.12'
       - run: bin/install_flint_ubuntu.sh ${{ matrix.flint-tag }}
       - run: pip install .
+      - run: python -m flint.test --verbose
+
+  # Test against flint main (with disabled version check)
+  test_flint_versions:
+    name: Test flint ${{ matrix.flint-tag }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Supported versions and latest git
+        flint-tag: ['main']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: bin/install_flint_ubuntu.sh ${{ matrix.flint-tag }}
+      - run: pip install --config-settings=setup-args="-Dflint_version_check=false" .
       - run: python -m flint.test --verbose
 
   # Deploy wheels and sdist to PyPI

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -156,7 +156,7 @@ jobs:
       # We don't need to specify ninja as a requirement in pyproject.toml
       # because without --no-build-isolation meson-python handles it
       # automatically in get_requirements_for_build_wheel().
-      - run: 'pip install cython==3.0 meson-python==0.13 ninja==1.9.0'
+      - run: 'pip install cython==3.0 meson-python==0.13 ninja==1.10'
       - run: pip install --no-build-isolation .
       - run: python -m flint.test --verbose
 

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -138,9 +138,9 @@ jobs:
       - run: pip install .
       - run: python -m flint.test --verbose
 
-  # Test that we can still make a coverage build with setuptools.
-  test_coverage_setuptools:
-    name: Test coverage setuptools build
+  # Test build with minimum Cython and meson-python versions.
+  test_old_build_requires:
+    name: 'Test old Cython/meson-python'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -149,29 +149,10 @@ jobs:
           python-version: '3.12'
       - run: sudo apt-get update
       - run: sudo apt-get install libflint-dev
-      - run: pip install git+https://github.com/oscarbenjamin/cython.git@pr_relative_paths
-      - run: pip install -r requirements-dev.txt
-      - run: bin/coverage.sh
-
-  # Run SymPy test suite against python-flint master
-  test_sympy:
-    name: Test SymPy ${{ matrix.sympy-version }}
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        sympy-version: ['1.13.1']
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - run: sudo apt-get update
-      - run: sudo apt-get install libflint-dev
-      - run: pip install .
-      - run: pip install pytest pytest-xdist hypothesis
-      - run: pip install sympy==${{ matrix.sympy-version }}
-      - run: python -c 'import sympy; sympy.test(parallel=True)'
+      # The versions here should be kept in sync with pyproject.toml.
+      - run: 'pip install cython==3.0 meson-python==0.13'
+      - run: pip install --no-build-isolation .
+      - run: python -m flint.test --verbose
 
   # For older Ubuntu we have to build Flint >= 3.0.0
   test_flint_releases:
@@ -208,6 +189,43 @@ jobs:
       - run: bin/install_flint_ubuntu.sh ${{ matrix.flint-tag }}
       - run: pip install --config-settings=setup-args="-Dflint_version_check=false" .
       - run: python -m flint.test --verbose
+
+  # Test that we can make a coverage build and report coverage
+  test_coverage_setuptools:
+    name: Test coverage setuptools build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: sudo apt-get update
+      - run: sudo apt-get install libflint-dev
+      # This is branch is for a Cython PR:
+      # https://github.com/cython/cython/pull/6341
+      - run: pip install git+https://github.com/oscarbenjamin/cython.git@pr_relative_paths
+      - run: pip install -r requirements-dev.txt
+      - run: bin/coverage.sh
+
+  # Run SymPy test suite against python-flint master
+  test_sympy:
+    name: Test SymPy ${{ matrix.sympy-version }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        sympy-version: ['1.13.1']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: sudo apt-get update
+      - run: sudo apt-get install libflint-dev
+      - run: pip install .
+      - run: pip install pytest pytest-xdist hypothesis
+      - run: pip install sympy==${{ matrix.sympy-version }}
+      - run: python -c 'import sympy; sympy.test(parallel=True)'
 
   # Deploy wheels and sdist to PyPI
 

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ matrix.os == 'windows-2019' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           # override setting in pyproject.toml to use msys2 instead of msys64 bash
           CIBW_BEFORE_ALL_WINDOWS: msys2 -c bin/cibw_before_all_windows.sh
@@ -167,7 +167,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Supported versions and latest git
+        # Supported Flint versions:
         flint-tag: ['v3.0.0', 'v3.0.1', 'v3.1.0', 'v3.1.1', 'v3.1.2']
     steps:
       - uses: actions/checkout@v4
@@ -178,26 +178,22 @@ jobs:
       - run: pip install .
       - run: python -m flint.test --verbose
 
-  # Test against flint main (with disabled version check)
+  # Test against flint main
   test_flint_main:
-    name: Test flint ${{ matrix.flint-tag }}
+    name: Test flint main
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        # Supported versions and latest git
-        flint-tag: ['main']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: bin/install_flint_ubuntu.sh ${{ matrix.flint-tag }}
+      - run: bin/install_flint_ubuntu.sh main
+      # Need to disable flint version check to build against main
       - run: pip install --config-settings=setup-args="-Dflint_version_check=false" .
       - run: python -m flint.test --verbose
 
   # Test that we can make a coverage build and report coverage
-  test_coverage_setuptools:
+  test_coverage_build:
     name: Test coverage setuptools build
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -156,7 +156,7 @@ jobs:
       # We don't need to specify ninja as a requirement in pyproject.toml
       # because without --no-build-isolation meson-python handles it
       # automatically in get_requirements_for_build_wheel().
-      - run: 'pip install cython==3.0 meson-python==0.13 ninja==1.8.2'
+      - run: 'pip install cython==3.0 meson-python==0.13 ninja==1.9.0'
       - run: pip install --no-build-isolation .
       - run: python -m flint.test --verbose
 

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -107,7 +107,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-13, macos-14]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13-dev']
 
     steps:
       - uses: actions/setup-python@v5

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -156,7 +156,7 @@ jobs:
       # We don't need to specify ninja as a requirement in pyproject.toml
       # because without --no-build-isolation meson-python handles it
       # automatically in get_requirements_for_build_wheel().
-      - run: 'pip install cython==3.0 meson-python==0.13 ninja==1.10'
+      - run: 'pip install cython==3.0 meson-python==0.13 ninja<1.11'
       - run: pip install --no-build-isolation .
       - run: python -m flint.test --verbose
 

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -174,7 +174,7 @@ jobs:
       - run: python -c 'import sympy; sympy.test(parallel=True)'
 
   # For older Ubuntu we have to build Flint >= 3.0.0
-  test_flint_versions:
+  test_flint_releases:
     name: Test flint ${{ matrix.flint-tag }}
     runs-on: ubuntu-22.04
     strategy:
@@ -192,7 +192,7 @@ jobs:
       - run: python -m flint.test --verbose
 
   # Test against flint main (with disabled version check)
-  test_flint_versions:
+  test_flint_main:
     name: Test flint ${{ matrix.flint-tag }}
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -149,11 +149,14 @@ jobs:
           python-version: '3.12'
       - run: sudo apt-get update
       - run: sudo apt-get install libflint-dev
-      # The versions here should be kept in sync with pyproject.toml.
-      # Not sure if ninja should be listed as a requirement in pyproject.toml
-      # as with newer meson-python it does not seem to be needed but this CI
-      # job would fail without it being installed explicitly here...
-      - run: 'pip install cython==3.0 meson-python'
+      # The versions of cython and meson-python here should be kept in sync
+      # with those in pyproject.toml so that we test the stated minimum
+      # versions.
+      #
+      # We don't need to specify ninja as a requirement in pyproject.toml
+      # because without --no-build-isolation meson-python handles it
+      # automatically in get_requirements_for_build_wheel().
+      - run: 'pip install cython==3.0 meson-python==0.13 ninja==1.8.2'
       - run: pip install --no-build-isolation .
       - run: python -m flint.test --verbose
 

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -156,7 +156,7 @@ jobs:
       # We don't need to specify ninja as a requirement in pyproject.toml
       # because without --no-build-isolation meson-python handles it
       # automatically in get_requirements_for_build_wheel().
-      - run: 'pip install cython==3.0 meson-python==0.13 ninja<1.11'
+      - run: 'pip install "cython==3.0" "meson-python==0.13" "ninja<1.11"'
       - run: pip install --no-build-isolation .
       - run: python -m flint.test --verbose
 

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ cc = meson.get_compiler('c')
 
 gmp_dep = dependency('gmp')
 mpfr_dep = dependency('mpfr')
-flint_dep = dependency('flint', version: ['>=3.1', '<3.2'])
+flint_dep = dependency('flint', version: ['>=3.0', '<3.2'])
 
 add_project_arguments(
     '-X', 'embedsignature=True',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,24 @@
 project('python-flint', 'cython', 'c')
 
+#
+# For the source release, we should by default fail for newer versions of Flint
+# that are untested with a nice error message:
+#
+#   ../meson.build:10:12:
+#   ERROR: Dependency lookup for flint with method 'pkgconfig' failed:
+#   Invalid version, need 'flint' ['<3.2'] found '3.2.0'.
+#
+# We need an option to disable this though so that we can test newer versions
+# of Flint. Also good to have an escape hatch for users since we don't know
+# that future versions of Flint will not work.
+#
+if get_option('flint_version_check')
+  flint_version_required = ['>=3.0', '<3.2']
+else
+  # We do know that Flint < 3.0 will not work so no point allowing it.
+  flint_version_required = ['>=3.0']
+endif
+
 py = import('python').find_installation(pure: false)
 dep_py = py.dependency()
 
@@ -7,7 +26,7 @@ cc = meson.get_compiler('c')
 
 gmp_dep = dependency('gmp')
 mpfr_dep = dependency('mpfr')
-flint_dep = dependency('flint', version: ['>=3.0', '<3.2'])
+flint_dep = dependency('flint', version: flint_version_required)
 
 add_project_arguments(
     '-X', 'embedsignature=True',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,17 @@
 project('python-flint', 'cython', 'c')
 
+py = import('python').find_installation(pure: false)
+dep_py = py.dependency()
+
+cc = meson.get_compiler('c')
+
+flint_ver_lower = '3.0' # >=3.0
+flint_ver_upper = '3.2' # <3.2
+
+gmp_dep = dependency('gmp')
+mpfr_dep = dependency('mpfr')
+flint_dep = dependency('flint', version: ['>=' + flint_ver_lower])
+
 #
 # For the source release, we should by default fail for newer versions of Flint
 # that are untested with a nice error message:
@@ -13,20 +25,31 @@ project('python-flint', 'cython', 'c')
 # that future versions of Flint will not work.
 #
 if get_option('flint_version_check')
-  flint_version_required = ['>=3.0', '<3.2']
-else
-  # We do know that Flint < 3.0 will not work so no point allowing it.
-  flint_version_required = ['>=3.0']
+  if flint_dep.version().version_compare('>=' + flint_ver_upper)
+    error('''
+
+      Invalid Flint version:
+      Version needed is: @0@ <= flint < @1@
+      Version found is: flint == @2@
+
+      By default, python-flint will only build against Flint versions that have
+      been tested. If you are sure you want to use this version of Flint, you
+      can disable this check with -Dflint_version_check=false.
+
+      If building from the source directory using meson directly, you can do
+      this with:
+
+        meson setup build -Dflint_version_check=false
+
+      If you are installing with pip, you can do this with:
+
+        pip install --config-settings=setup-args="-Dflint_version_check=false" python-flint
+
+      Other build frontends have similar options for passing this to meson.
+      '''.format(flint_ver_lower, flint_ver_upper, flint_dep.version())
+    )
+  endif
 endif
-
-py = import('python').find_installation(pure: false)
-dep_py = py.dependency()
-
-cc = meson.get_compiler('c')
-
-gmp_dep = dependency('gmp')
-mpfr_dep = dependency('mpfr')
-flint_dep = dependency('flint', version: flint_version_required)
 
 add_project_arguments(
     '-X', 'embedsignature=True',

--- a/meson.build
+++ b/meson.build
@@ -13,12 +13,15 @@ mpfr_dep = dependency('mpfr')
 flint_dep = dependency('flint', version: ['>=' + flint_ver_lower])
 
 #
-# For the source release, we should by default fail for newer versions of Flint
-# that are untested with a nice error message:
+# The minimum Flint version is because we know that it will not work with
+# earlier versions. The maximum version is because python-flint has not been
+# tested against versions that didn't exist at the time of release. In future
+# if it seems like new Flint releases do not break the build of python-flint
+# every time, then we can consider not using a speculative upper version cap
+# here.
 #
-#   ../meson.build:10:12:
-#   ERROR: Dependency lookup for flint with method 'pkgconfig' failed:
-#   Invalid version, need 'flint' ['<3.2'] found '3.2.0'.
+# For the source release, we should by default fail for newer versions of Flint
+# that are untested with a nice error message.
 #
 # We need an option to disable this though so that we can test newer versions
 # of Flint. Also good to have an escape hatch for users since we don't know
@@ -28,26 +31,25 @@ if get_option('flint_version_check')
   if flint_dep.version().version_compare('>=' + flint_ver_upper)
     error('''
 
-      Invalid Flint version:
-      Version needed is: @0@ <= flint < @1@
-      Version found is: flint == @2@
+    Invalid Flint version:
+    Version needed is: @0@ <= flint < @1@
+    Version found is: flint == @2@
 
-      By default, python-flint will only build against Flint versions that have
-      been tested. If you are sure you want to use this version of Flint, you
-      can disable this check with -Dflint_version_check=false.
+    By default, python-flint will only build against Flint versions that have
+    been tested. If you are sure you want to use this version of Flint, you can
+    disable this check with -Dflint_version_check=false.
 
-      If building from the source directory using meson directly, you can do
-      this with:
+    If building from the source directory using meson directly, you can do this
+    with:
 
-        meson setup build -Dflint_version_check=false
+      meson setup build -Dflint_version_check=false
 
-      If you are installing with pip, you can do this with:
+    If you are installing with pip, you can do this with:
 
-        pip install --config-settings=setup-args="-Dflint_version_check=false" python-flint
+      pip install --config-settings=setup-args="-Dflint_version_check=false" python-flint
 
-      Other build frontends have similar options for passing this to meson.
-      '''.format(flint_ver_lower, flint_ver_upper, flint_dep.version())
-    )
+    Other build frontends have similar options for passing this to meson.
+    '''.format(flint_ver_lower, flint_ver_upper, flint_dep.version()))
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ cc = meson.get_compiler('c')
 
 gmp_dep = dependency('gmp')
 mpfr_dep = dependency('mpfr')
-flint_dep = dependency('flint')
+flint_dep = dependency('flint', version: ['>=3.1', '<3.2'])
 
 add_project_arguments(
     '-X', 'embedsignature=True',

--- a/meson.options
+++ b/meson.options
@@ -1,2 +1,3 @@
 option('coverage', type : 'boolean', value : false, description : 'enable coverage build')
 option('add_flint_rpath', type : 'boolean', value : false)
+option('flint_version_check', type: 'boolean', value : true)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "python-flint"
-description = "Bindings for FLINT and Arb"
+description = "Bindings for FLINT"
 version = "0.7.0a4"
+requires-python = ">= 3.9"
 urls = {Homepage = "https://github.com/flintlib/python-flint"}
 authors = [
     {name = "Fredrik Johansson", email = "fredrik.johansson@gmail.com"},
@@ -54,6 +55,8 @@ package = "flint"
 ]
 
 [tool.cibuildwheel]
+# requires-python needs to keep in sync with this and also the list of Python
+# versions the wheels are tested against in CI.
 build = "cp39-* cp310-* cp311-* cp312-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux_*"
 manylinux-x86_64-image = "manylinux2014"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[build-system]
-# Minimum build requirements tested in CI need to be kept in sync with this.
-requires = ["meson-python>=0.13", "cython>=3.0"]
-build-backend = "mesonpy"
-
 [project]
 name = "python-flint"
 description = "Bindings for FLINT and Arb"
@@ -19,6 +14,11 @@ classifiers = [
 [project.readme]
 file = "README.md"
 content-type = "text/markdown"
+
+[build-system]
+# Minimum build requirements tested in CI need to be kept in sync with this.
+requires = ["meson-python>=0.13", "cython>=3.0"]
+build-backend = "mesonpy"
 
 [tool.spin]
 package = "flint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["meson-python", "cython"]
+# Minimum build requirements tested in CI need to be kept in sync with this.
+requires = ["meson-python>=0.13", "cython>=3.0"]
 build-backend = "mesonpy"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ package = "flint"
 [tool.cibuildwheel]
 # requires-python needs to keep in sync with this and also the list of Python
 # versions the wheels are tested against in CI.
-build = "cp39-* cp310-* cp311-* cp312-*"
+build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux_*"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,20 @@ file = "README.md"
 content-type = "text/markdown"
 
 [build-system]
-# Minimum build requirements tested in CI need to be kept in sync with this.
-requires = ["meson-python>=0.13", "cython>=3.0"]
+#
+# Minimum build requirements tested in CI need to be kept in sync with the
+# versions in requires below so that they are tested.
+#
+# The upper cap on Cython is speculative but we may as well cap it given that
+# it is only a build requirement and that it is not uncommon for newer Cython
+# versions to break the build. For example Cython 3.0 broke the build and then
+# Cython 3.1 broke the build again so python-flint 0.6.0 did not have any upper
+# cap but it should have had cython>=3.0,<3.1 i.e. precisely one minor release
+# of Cython works. In future we could contemplate not having an upper cap but
+# until we have actually witnessed a Cython 3.x release that does not break the
+# build we should keep the upper cap.
+#
+requires = ["meson-python>=0.13", "cython>=3.0,<3.1"]
 build-backend = "mesonpy"
 
 [tool.spin]


### PR DESCRIPTION
Set version constraints on build requirements so that someone in the long distant future will be able to build the next release of python-flint.

Closes gh-193.