### PR TITLE
Include ruff

### DIFF
--- a/coverage_plugin.py
+++ b/coverage_plugin.py
@@ -9,11 +9,7 @@ easier to find all the C files because we can just parse the build.ninja file.
 https://coverage.readthedocs.io/en/latest/api_plugin.html
 https://github.com/cython/cython/blob/master/Cython/Coverage.py
 """
-import re
-from collections import defaultdict
-
 from coverage.plugin import CoveragePlugin, FileTracer, FileReporter
-
 from functools import cache
 from pathlib import Path
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,8 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,77 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py38"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/ruff.toml
+++ b/ruff.toml
@@ -40,7 +40,7 @@ target-version = "py38"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["E4", "E7", "E9", "F"]
-ignore = []
+ignore = ["E731"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -40,7 +40,9 @@ target-version = "py38"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["E4", "E7", "E9", "F"]
-ignore = ["E731"]
+# 27	F403	[ ] undefined-local-with-import-star
+# 16	E731	[*] lambda-assignment
+ignore = ["F403", "E731"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -40,12 +40,10 @@ target-version = "py38"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["E4", "E7", "E9", "F"]
-# - We ignore F403 (undefined-local-with-import-star) as these star inports 
-#   are used throughout the module
 # - We ignore E731 (lambda-assignment) as we use these in testing
 # - We ignore E741 (ambiguous-variable-name) as often these one letter
 #   variables make sense for mathematical functions
-ignore = ["F403", "E731", "E741"]
+ignore = ["E731", "E741"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -40,9 +40,12 @@ target-version = "py38"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["E4", "E7", "E9", "F"]
-# 27	F403	[ ] undefined-local-with-import-star
-# 16	E731	[*] lambda-assignment
-ignore = ["F403", "E731"]
+# - We ignore F403 (undefined-local-with-import-star) as these star inports 
+#   are used throughout the module
+# - We ignore E731 (lambda-assignment) as we use these in testing
+# - We ignore E741 (ambiguous-variable-name) as often these one letter
+#   variables make sense for mathematical functions
+ignore = ["F403", "E731", "E741"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import sys
 import os
-from subprocess import check_call
 
 from Cython.Distutils import build_ext
 from Cython.Build import cythonize

--- a/src/flint/__init__.py
+++ b/src/flint/__init__.py
@@ -45,7 +45,7 @@ from .functions.showgood import good, showgood
 from .flint_base.flint_base import (
     FLINT_VERSION as __FLINT_VERSION__,
     FLINT_RELEASE as __FLINT_RELEASE__,
-    Ordering,
+    Ordering as Ordering
 )
 
 __version__ = '0.7.0a4'

--- a/src/flint/test/__main__.py
+++ b/src/flint/test/__main__.py
@@ -35,7 +35,7 @@ def run_tests(verbose=None):
         try:
             test()
         except Exception as e:
-            print(f'Error in {test.__name__}')
+            print(f'Error in {test.__name__}, {e = }')
             if verbose:
                 traceback.print_exc()
             failed += 1

--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -47,7 +47,7 @@ def test_pyflint():
         ctx.prec = oldprec
 
     assert ctx.dps == 15
-    olddps = ctx.dps
+
     try:
         f1 = flint.arb(2).sqrt()
         ctx.dps = 3
@@ -1530,7 +1530,6 @@ def test_nmod_mat():
     assert (M2.nrows(), M2.ncols()) == (3, 4)
     M3 = M(2,2,[1,2,3,4],17)
     assert M3[0,1] == G(2,17)
-    M3_copy = M(M3)
     M3[0,1] = -1
     assert M3[0,1] == G(-1,17)
     def set_bad(i,j):

--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -2803,7 +2803,7 @@ def test_polys():
         assert P([1, 2, 1]).derivative() == P([2, 2])
 
         p = P([1, 2, 1])
-        if is_field and type(p) is flint.fq_default_poly:
+        if is_field and type(p) is not flint.fq_default_poly:
             assert p.integral() == P([0, 1, 1, S(1)/3])
         if type(p) is flint.fq_default_poly:
             assert raises(lambda: p.integral(), NotImplementedError)

--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -197,8 +197,8 @@ def test_fmpz():
     assert abs(flint.fmpz(1)) == 1
     assert abs(flint.fmpz(-1)) == 1
 
-    assert bool(flint.fmpz(0)) == False
-    assert bool(flint.fmpz(1)) == True
+    assert bool(flint.fmpz(0)) is False
+    assert bool(flint.fmpz(1)) is True
 
     assert flint.fmpz(2).bit_length() == 2
     assert flint.fmpz(-2).bit_length() == 2
@@ -430,8 +430,8 @@ def test_fmpz_poly():
     assert p.degree() == 1
     assert p.coeffs() == [3,2]
     assert Z([]).coeffs() == []
-    assert bool(Z([])) == False
-    assert bool(Z([1])) == True
+    assert bool(Z([])) is False
+    assert bool(Z([1])) is True
     ctx.pretty = False
     assert repr(Z([1,2])) == "fmpz_poly([1, 2])"
     ctx.pretty = True
@@ -534,8 +534,8 @@ def test_fmpz_mat():
     assert (C.nrows(),C.ncols()) == (7,2)
     assert A*(B*C) == (A*B)*C
     assert raises(lambda: A*C, ValueError)
-    assert bool(M(2,2,[0,0,0,0])) == False
-    assert bool(M(2,2,[0,0,0,1])) == True
+    assert bool(M(2,2,[0,0,0,0])) is False
+    assert bool(M(2,2,[0,0,0,1])) is True
     ctx.pretty = False
     assert repr(M(2,2,[1,2,3,4])) == 'fmpz_mat(2, 2, [1, 2, 3, 4])'
     ctx.pretty = True
@@ -762,8 +762,8 @@ def test_fmpq():
     assert raises(lambda: Q([]), TypeError)
     assert raises(lambda: Q(1, []), TypeError)
     assert raises(lambda: Q([], 1), TypeError)
-    assert bool(Q(0)) == False
-    assert bool(Q(1)) == True
+    assert bool(Q(0)) is False
+    assert bool(Q(1)) is True
     assert Q(1,3) + Q(2,3) == 1
     assert Q(1,3) - Q(2,3) == Q(-1,3)
     assert Q(1,3) * Q(2,3) == Q(2,9)
@@ -924,8 +924,8 @@ def test_fmpq_poly():
     assert raises(lambda: Q({}), TypeError)
     assert raises(lambda: Q([1], []), TypeError)
     assert raises(lambda: Q([1], 0), ZeroDivisionError)
-    assert bool(Q()) == False
-    assert bool(Q([1])) == True
+    assert bool(Q()) is False
+    assert bool(Q([1])) is True
     assert Q(Q([1,2])) == Q([1,2])
     assert Q(Z([1,2])) == Q([1,2])
     assert Q([1,2]) + 3 == Q([4,2])
@@ -1497,8 +1497,8 @@ def test_nmod_mat():
     B = M(3,7,Z.randtest(3,7,5).entries(),17)
     C = M(7,2,Z.randtest(7,2,5).entries(),17)
     assert A*(B*C) == (A*B)*C
-    assert bool(M(2,2,[0,0,0,0],17)) == False
-    assert bool(M(2,2,[0,0,0,1],17)) == True
+    assert bool(M(2,2,[0,0,0,0],17)) is False
+    assert bool(M(2,2,[0,0,0,1],17)) is True
     pretty = ctx.pretty
     try:
         ctx.pretty = False

--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -1,8 +1,6 @@
-import sys
 import math
 import operator
 import pickle
-import doctest
 import platform
 
 from flint.utils.flint_exceptions import DomainError, IncompatibleContextError

--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -126,7 +126,7 @@ def test_fmpz():
                         assert raises(lambda: ltype(s) >> rtype(t), ValueError)
 
     assert 2 ** flint.fmpz(2) == 4
-    assert type(2 ** flint.fmpz(2)) == flint.fmpz
+    assert type(2 ** flint.fmpz(2)) is flint.fmpz
     assert raises(lambda: () ** flint.fmpz(1), TypeError)
     assert raises(lambda: flint.fmpz(1) ** (), TypeError)
     assert raises(lambda: flint.fmpz(1) ** -1, ValueError)
@@ -2305,7 +2305,7 @@ def test_fmpz_mod_mat():
     assert M.nrows() == 3
     assert M.ncols() == 3
     assert M.entries() == [flint.fmpz_mod(i, c11) for i in [1,2,3,4,5,6,7,8,9]]
-    assert type(M[0,0]) == flint.fmpz_mod
+    assert type(M[0,0]) is flint.fmpz_mod
     assert M[0,0] == 1
     assert raises(lambda: flint.fmpz_mod_mat([[1]]), TypeError)
     assert raises(lambda: flint.fmpz_mod_mat([[1,2],[3,4]], c11, c11), TypeError)
@@ -2622,15 +2622,15 @@ def test_polys():
 
         for v in [], [1], [1, 2]:
             p = P(v)
-            if type(p) == flint.fmpz_poly:
+            if type(p) is flint.fmpz_poly:
                 assert P(v).repr() == f'fmpz_poly({v!r})'
-            elif type(p) == flint.fmpq_poly:
+            elif type(p) is flint.fmpq_poly:
                 assert P(v).repr() == f'fmpq_poly({v!r})'
-            elif type(p) == flint.nmod_poly:
+            elif type(p) is flint.nmod_poly:
                 assert P(v).repr() == f'nmod_poly({v!r}, {p.modulus()})'
-            elif type(p) == flint.fmpz_mod_poly:
+            elif type(p) is flint.fmpz_mod_poly:
                 pass # fmpz_mod_poly does not have .repr() ...
-            elif type(p) == flint.fq_default_poly:
+            elif type(p) is flint.fq_default_poly:
                 pass # fq_default_poly does not have .repr() ...
             else:
                 assert False
@@ -2803,9 +2803,9 @@ def test_polys():
         assert P([1, 2, 1]).derivative() == P([2, 2])
 
         p = P([1, 2, 1])
-        if is_field and type(p) != flint.fq_default_poly:
+        if is_field and type(p) is flint.fq_default_poly:
             assert p.integral() == P([0, 1, 1, S(1)/3])
-        if type(p) == flint.fq_default_poly:
+        if type(p) is flint.fq_default_poly:
             assert raises(lambda: p.integral(), NotImplementedError)
 
 

--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -1523,8 +1523,8 @@ def test_nmod_mat():
     assert raises(lambda: M([[0]],13) < M([[1]],13), TypeError)
     assert (M([[1]],17) == M([[1]],13)) is False
     assert (M([[1]],17) != M([[1]],13)) is True
-    assert (M([[1]],17) == None) is False
-    assert (M([[1]],17) != None) is True
+    assert (M([[1]],17) is None) is False
+    assert (M([[1]],17) is not None) is True
     M2 = M.randtest(3,4,5)
     assert all(0 <= int(x) < 5 for x in M2.entries())
     assert (M2.nrows(), M2.ncols()) == (3, 4)
@@ -2591,10 +2591,8 @@ def test_polys():
         assert (s1 == P([s2])) is False
         assert (s1 != P([s2])) is True
 
-        assert (P([1]) == None) is False
-        assert (P([1]) != None) is True
-        assert (None == P([1])) is False
-        assert (None != P([1])) is True
+        assert (P([1]) is None) is False
+        assert (P([1]) is not None) is True
 
         assert raises(lambda: P([1]) < P([1]), TypeError)
         assert raises(lambda: P([1]) <= P([1]), TypeError)
@@ -2937,10 +2935,8 @@ def test_mpolys():
         assert (P(1, ctx=ctx) == P(1, ctx=ctx1)) is False
         assert (P(1, ctx=ctx) != P(1, ctx=ctx1)) is True
 
-        assert (P(1, ctx=ctx) == None) is False
-        assert (P(1, ctx=ctx) != None) is True
-        assert (None == P(1, ctx=ctx)) is False
-        assert (None != P(1, ctx=ctx)) is True
+        assert (P(1, ctx=ctx) is None) is False
+        assert (P(1, ctx=ctx) is not None) is True
 
         assert P(ctx.from_dict({(0, 1): 3})) == ctx.from_dict({(0, 1): 3})
         assert P({(0, 1): 3}, ctx=ctx) == ctx.from_dict({(0, 1): 3})
@@ -3676,10 +3672,8 @@ def test_matrices_eq():
         assert (A1 != A2) is False
         assert (A1 == B) is False
         assert (A1 != B) is True
-        assert (A1 == None) is False
-        assert (A1 != None) is True
-        assert (None == A1) is False
-        assert (None != A1) is True
+        assert (A1 is None) is False
+        assert (A1 is not None) is True
         assert raises(lambda: A1 < A2, TypeError)
         assert raises(lambda: A1 <= A2, TypeError)
         assert raises(lambda: A1 > A2, TypeError)


### PR DESCRIPTION
Currently `ruff.toml` is the default settings, feel free to suggest changes. 

The current output of `ruff` statistics is:

```
Jack: python-flint % ruff check --statistics
29	F401	[ ] unused-import
27	F403	[ ] undefined-local-with-import-star
16	E731	[*] lambda-assignment
14	E711	[*] none-comparison
12	E712	[*] true-false-comparison
 9	E721	[ ] type-comparison
 7	E741	[ ] ambiguous-variable-name
 3	F841	[*] unused-variable
 1	E401	[*] multiple-imports-on-one-line
```

I will try and fix these one at a time in some commits.