### PR TITLE
fix faulty test in fq_default_poly

### DIFF
--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -4461,7 +4461,11 @@ def test_fq_default_poly():
         assert raises(lambda: f.compose_mod(g, R_test.zero()), ZeroDivisionError)
 
         # inverse_mod
-        f = R_test.random_element()
+        while True:
+            # Ensure f is invertible
+            f = R_test.random_element()
+            if not f.constant_coefficient().is_zero():
+                break
         while True:
             h = R_test.random_element()
             if f.gcd(h).is_one():


### PR DESCRIPTION
In response to #221 I have amended the test for the error when trying to invert polynomials where the constant coefficient is zero (only case where it is non-invertible) 