### PR TITLE
Improve mpoly context interface

### DIFF
--- a/src/flint/flint_base/flint_base.pxd
+++ b/src/flint/flint_base/flint_base.pxd
@@ -57,8 +57,5 @@ cdef class flint_mat(flint_elem):
 cdef class flint_series(flint_elem):
     pass
 
-cpdef enum Ordering:
-    lex, deglex, degrevlex
-
-cdef ordering_t ordering_py_to_c(ordering: Ordering)
+cdef ordering_t ordering_py_to_c(ordering)
 cdef ordering_c_to_py(ordering_t ordering)

--- a/src/flint/flint_base/flint_base.pxd
+++ b/src/flint/flint_base/flint_base.pxd
@@ -13,6 +13,9 @@ cdef class flint_mpoly_context(flint_elem):
     cdef public object py_names
     cdef const char ** c_names
 
+cdef class flint_mod_mpoly_context(flint_mpoly_context):
+    cdef readonly bint __prime_modulus
+
 cdef class flint_mpoly(flint_elem):
     cdef _add_scalar_(self, other)
     cdef _sub_scalar_(self, other)

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -424,7 +424,7 @@ cdef class flint_mpoly_context(flint_elem):
         to ``1``. ``exp_vec``` defaults to ``(0,) * self.nvars()```.
 
             >>> from flint import fmpz_mpoly_ctx, Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> ctx.term(coeff=5, exp_vec=(2, 3))
             5*x0^2*x1^3
             >>> ctx.term()
@@ -465,11 +465,11 @@ cdef class flint_mod_mpoly_context(flint_mpoly_context):
         """
         Return whether the modulus is prime
 
-            >>> from flint import Ordering, fmpz_mod_mpoly_ctx
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(4, Ordering.degrevlex, 2**127, 'z')
+            >>> from flint import fmpz_mod_mpoly_ctx
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('z',), 2**127, 'degrevlex')
             >>> ctx.is_prime()
             False
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(4, Ordering.degrevlex, 2**127 - 1, 'z')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('z',), 2**127 - 1, 'degrevlex')
             >>> ctx.is_prime()
             True
         """
@@ -746,8 +746,8 @@ cdef class flint_mpoly(flint_elem):
         """
         In-place addition, mutates self.
 
-            >>> from flint import Ordering, fmpz_mpoly_ctx
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> from flint import fmpz_mpoly_ctx
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f
             4*x0*x1 + 2*x0 + 3*x1
@@ -771,8 +771,8 @@ cdef class flint_mpoly(flint_elem):
         """
         In-place subtraction, mutates self.
 
-            >>> from flint import Ordering, fmpz_mpoly_ctx
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> from flint import fmpz_mpoly_ctx
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f
             4*x0*x1 + 2*x0 + 3*x1
@@ -796,8 +796,8 @@ cdef class flint_mpoly(flint_elem):
         """
         In-place multiplication, mutates self.
 
-            >>> from flint import Ordering, fmpz_mpoly_ctx
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> from flint import fmpz_mpoly_ctx
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f
             4*x0*x1 + 2*x0 + 3*x1
@@ -822,7 +822,7 @@ cdef class flint_mpoly(flint_elem):
         Returns True if ``self`` contains a term with exponent vector ``x`` and a non-zero coefficient.
 
             >>> from flint import fmpq_mpoly_ctx, Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> (1, 1) in p
             True
@@ -843,7 +843,7 @@ cdef class flint_mpoly(flint_elem):
         Return the exponent vectors and coefficient of each term.
 
             >>> from flint import fmpq_mpoly_ctx, Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> list(f.terms())
             [((1, 1), 4), ((1, 0), 2), ((0, 1), 3), ((0, 0), 1)]

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -264,7 +264,7 @@ cdef class flint_poly(flint_elem):
         raise NotImplementedError("Complex roots are not supported for this polynomial")
 
 
-class Ordering(enum.StrEnum):
+class Ordering(enum.Enum):
     lex = "lex"
     deglex = "deglex"
     degrevlex = "degrevlex"

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -438,7 +438,7 @@ cdef class flint_mpoly_context(flint_elem):
         Create a monomial from a coefficient and exponent vector. ``coeff`` defaults
         to ``1``. ``exp_vec``` defaults to ``(0,) * self.nvars()```.
 
-            >>> from flint import fmpz_mpoly_ctx, Ordering
+            >>> from flint import fmpz_mpoly_ctx
             >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> ctx.term(coeff=5, exp_vec=(2, 3))
             5*x0^2*x1^3
@@ -839,7 +839,7 @@ cdef class flint_mpoly(flint_elem):
         """
         Returns True if ``self`` contains a term with exponent vector ``x`` and a non-zero coefficient.
 
-            >>> from flint import fmpq_mpoly_ctx, Ordering
+            >>> from flint import fmpq_mpoly_ctx
             >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> (1, 1) in p
@@ -860,7 +860,7 @@ cdef class flint_mpoly(flint_elem):
         """
         Return the exponent vectors and coefficient of each term.
 
-            >>> from flint import fmpq_mpoly_ctx, Ordering
+            >>> from flint import fmpq_mpoly_ctx
             >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> list(f.terms())

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -354,7 +354,7 @@ cdef class flint_mpoly_context(flint_elem):
         """
         res: list[str] = []
 
-        # Provide a convenience method to avoid having to pass a nested tuple
+        # To avoid having to pass a nested tuple we allow a tuple[str, int]
         if len(names) == 2 and isinstance(names[0], str) and isinstance(names[1], int):
             names = (names,)
 
@@ -378,15 +378,10 @@ cdef class flint_mpoly_context(flint_elem):
         """
         Create a key for the context cache via the variable names and the ordering.
         """
-        # A type hint of ``ordering: Ordering`` results in the error "TypeError: an integer is required" if a Ordering
-        # object is not provided. This is pretty obtuse so we check its type ourselves
-        # if not isinstance(ordering, Ordering):
-        #     raise TypeError(f"'ordering' ('{ordering}') is not an instance of flint.Ordering")
-
         return cls.create_variable_names(names), Ordering(ordering) if not isinstance(ordering, Ordering) else ordering
 
     @classmethod
-    def get_context(cls, *args, **kwargs):
+    def get(cls, *args, **kwargs):
         """
         Retrieve or create a context via generator names, ``names`` and the ordering, ``ordering``.
 
@@ -401,7 +396,7 @@ cdef class flint_mpoly_context(flint_elem):
 
     @classmethod
     def from_context(cls, ctx: flint_mpoly_context):
-        return cls.get_context(
+        return cls.get(
             ordering=ctx.ordering(),
             names=ctx.names(),
         )
@@ -424,7 +419,7 @@ cdef class flint_mpoly_context(flint_elem):
         to ``1``. ``exp_vec``` defaults to ``(0,) * self.nvars()```.
 
             >>> from flint import fmpz_mpoly_ctx, Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> ctx.term(coeff=5, exp_vec=(2, 3))
             5*x0^2*x1^3
             >>> ctx.term()
@@ -455,7 +450,7 @@ cdef class flint_mod_mpoly_context(flint_mpoly_context):
 
     @classmethod
     def from_context(cls, ctx: flint_mod_mpoly_context):
-        return cls.get_context(
+        return cls.get(
             names=ctx.names(),
             modulus=ctx.modulus(),
             ordering=ctx.ordering(),
@@ -466,10 +461,10 @@ cdef class flint_mod_mpoly_context(flint_mpoly_context):
         Return whether the modulus is prime
 
             >>> from flint import fmpz_mod_mpoly_ctx
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('z',), 2**127, 'degrevlex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('z',), 2**127, 'degrevlex')
             >>> ctx.is_prime()
             False
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('z',), 2**127 - 1, 'degrevlex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('z',), 2**127 - 1, 'degrevlex')
             >>> ctx.is_prime()
             True
         """
@@ -747,7 +742,7 @@ cdef class flint_mpoly(flint_elem):
         In-place addition, mutates self.
 
             >>> from flint import fmpz_mpoly_ctx
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f
             4*x0*x1 + 2*x0 + 3*x1
@@ -772,7 +767,7 @@ cdef class flint_mpoly(flint_elem):
         In-place subtraction, mutates self.
 
             >>> from flint import fmpz_mpoly_ctx
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f
             4*x0*x1 + 2*x0 + 3*x1
@@ -797,7 +792,7 @@ cdef class flint_mpoly(flint_elem):
         In-place multiplication, mutates self.
 
             >>> from flint import fmpz_mpoly_ctx
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f
             4*x0*x1 + 2*x0 + 3*x1
@@ -822,7 +817,7 @@ cdef class flint_mpoly(flint_elem):
         Returns True if ``self`` contains a term with exponent vector ``x`` and a non-zero coefficient.
 
             >>> from flint import fmpq_mpoly_ctx, Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> (1, 1) in p
             True
@@ -843,7 +838,7 @@ cdef class flint_mpoly(flint_elem):
         Return the exponent vectors and coefficient of each term.
 
             >>> from flint import fmpq_mpoly_ctx, Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> list(f.terms())
             [((1, 1), 4), ((1, 0), 2), ((0, 1), 3), ((0, 0), 1)]

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -2,7 +2,6 @@ from flint.flintlib.types.flint cimport (
     FLINT_BITS as _FLINT_BITS,
     FLINT_VERSION as _FLINT_VERSION,
     __FLINT_RELEASE as _FLINT_RELEASE,
-    slong
 )
 from flint.utils.flint_exceptions import DomainError
 from flint.flintlib.types.mpoly cimport ordering_t
@@ -10,7 +9,6 @@ from flint.flint_base.flint_context cimport thectx
 from flint.utils.typecheck cimport typecheck
 cimport libc.stdlib
 
-from typing import Optional
 from collections.abc import Iterable
 from flint.utils.flint_exceptions import IncompatibleContextError
 

--- a/src/flint/flint_base/flint_base.pyx
+++ b/src/flint/flint_base/flint_base.pyx
@@ -379,10 +379,10 @@ cdef class flint_mpoly_context(flint_elem):
             nametup=ctx.names()
         )
 
-    def any_as_scalar(self, other):
+    def _any_as_scalar(self, other):
         raise NotImplementedError("abstract method")
 
-    def scalar_as_mpoly(self, other):
+    def _scalar_as_mpoly(self, other):
         raise NotImplementedError("abstract method")
 
     def compatible_context_check(self, other):
@@ -505,7 +505,7 @@ cdef class flint_mpoly(flint_elem):
             self.context().compatible_context_check(other.context())
             return self._add_mpoly_(other)
 
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
@@ -516,7 +516,7 @@ cdef class flint_mpoly(flint_elem):
             self.context().compatible_context_check(other.context())
             return self._add_mpoly_(other)
 
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
@@ -527,7 +527,7 @@ cdef class flint_mpoly(flint_elem):
             self.context().compatible_context_check(other.context())
             return self._sub_mpoly_(other)
 
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
@@ -538,7 +538,7 @@ cdef class flint_mpoly(flint_elem):
             self.context().compatible_context_check(other.context())
             return self._rsub_mpoly_(other)
 
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
@@ -549,7 +549,7 @@ cdef class flint_mpoly(flint_elem):
             self.context().compatible_context_check(other.context())
             return self._mul_mpoly_(other)
 
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
@@ -560,7 +560,7 @@ cdef class flint_mpoly(flint_elem):
             self.context().compatible_context_check(other.context())
             return self._mul_mpoly_(other)
 
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
@@ -586,20 +586,20 @@ cdef class flint_mpoly(flint_elem):
             self._division_check(other)
             return self._divmod_mpoly_(other)
 
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
-        other = self.context().scalar_as_mpoly(other)
+        other = self.context()._scalar_as_mpoly(other)
         self._division_check(other)
         return self._divmod_mpoly_(other)
 
     def __rdivmod__(self, other):
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
-        other = self.context().scalar_as_mpoly(other)
+        other = self.context()._scalar_as_mpoly(other)
         other._division_check(self)
         return self._rdivmod_mpoly_(other)
 
@@ -609,7 +609,7 @@ cdef class flint_mpoly(flint_elem):
             self._division_check(other)
             return self._truediv_mpoly_(other)
 
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
@@ -618,15 +618,15 @@ cdef class flint_mpoly(flint_elem):
         if res is not NotImplemented:
             return res
 
-        other = self.context().scalar_as_mpoly(other)
+        other = self.context()._scalar_as_mpoly(other)
         return self._truediv_mpoly_(other)
 
     def __rtruediv__(self, other):
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
-        other = self.context().scalar_as_mpoly(other)
+        other = self.context()._scalar_as_mpoly(other)
         other._division_check(self)
         return self._rtruediv_mpoly_(other)
 
@@ -636,20 +636,20 @@ cdef class flint_mpoly(flint_elem):
             self._division_check(other)
             return self._floordiv_mpoly_(other)
 
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
-        other = self.context().scalar_as_mpoly(other)
+        other = self.context()._scalar_as_mpoly(other)
         self._division_check(other)
         return self._floordiv_mpoly_(other)
 
     def __rfloordiv__(self, other):
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
-        other = self.context().scalar_as_mpoly(other)
+        other = self.context()._scalar_as_mpoly(other)
         other._division_check(self)
         return self._rfloordiv_mpoly_(other)
 
@@ -659,20 +659,20 @@ cdef class flint_mpoly(flint_elem):
             self._division_check(other)
             return self._mod_mpoly_(other)
 
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
-        other = self.context().scalar_as_mpoly(other)
+        other = self.context()._scalar_as_mpoly(other)
         self._division_check(other)
         return self._mod_mpoly_(other)
 
     def __rmod__(self, other):
-        other = self.context().any_as_scalar(other)
+        other = self.context()._any_as_scalar(other)
         if other is NotImplemented:
             return NotImplemented
 
-        other = self.context().scalar_as_mpoly(other)
+        other = self.context()._scalar_as_mpoly(other)
         other._division_check(self)
         return self._rmod_mpoly_(other)
 
@@ -695,7 +695,7 @@ cdef class flint_mpoly(flint_elem):
             self._iadd_mpoly_(other)
             return
 
-        other_scalar = self.context().any_as_scalar(other)
+        other_scalar = self.context()._any_as_scalar(other)
         if other_scalar is NotImplemented:
             raise NotImplementedError(f"cannot add {type(self)} and {type(other)}")
 
@@ -720,7 +720,7 @@ cdef class flint_mpoly(flint_elem):
             self._isub_mpoly_(other)
             return
 
-        other_scalar = self.context().any_as_scalar(other)
+        other_scalar = self.context()._any_as_scalar(other)
         if other_scalar is NotImplemented:
             raise NotImplementedError(f"cannot subtract {type(self)} and {type(other)}")
 
@@ -745,7 +745,7 @@ cdef class flint_mpoly(flint_elem):
             self._imul_mpoly_(other)
             return
 
-        other_scalar = self.context().any_as_scalar(other)
+        other_scalar = self.context()._any_as_scalar(other)
         if other_scalar is NotImplemented:
             raise NotImplementedError(f"cannot multiply {type(self)} and {type(other)}")
 

--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -2859,11 +2859,11 @@ def test_mpolys():
         # division is exact or not.
         composite_characteristic = characteristic != 0 and not characteristic.is_prime()
 
-        ctx = get_context((("x", 2),))
+        ctx = get_context(("x", 2))
 
         assert raises(lambda : ctx.__class__("x", flint.Ordering.lex), RuntimeError)
-        assert raises(lambda: get_context((("x", 2),), ordering="bad"), ValueError)
-        assert raises(lambda: get_context((("x", -1),)), ValueError)
+        assert raises(lambda: get_context(("x", 2), ordering="bad"), ValueError)
+        assert raises(lambda: get_context(("x", -1)), ValueError)
         assert raises(lambda: ctx.constant("bad"), TypeError)
         assert raises(lambda: ctx.from_dict("bad"), ValueError)
         assert raises(lambda: ctx.from_dict({(0, 0): "bad"}), TypeError)
@@ -2891,10 +2891,10 @@ def test_mpolys():
         assert ctx.nvars() == 2
         assert ctx.ordering() == flint.Ordering.lex
 
-        ctx1 = get_context((("x", 4),))
+        ctx1 = get_context(("x", 4))
         assert [ctx1.name(i) for i in range(4)] == ['x0', 'x1', 'x2', 'x3']
         for order in list(flint.Ordering):
-            ctx1 = get_context((("x", 4),), ordering=order)
+            ctx1 = get_context(("x", 4), ordering=order)
             assert ctx1.ordering() == order
 
         assert ctx.constant(1) == mpoly({(0, 0): 1}) == P(1, ctx=ctx)

--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -2104,7 +2104,7 @@ def test_fmpz_mod_poly():
         assert pow(f, 2**60, g) == pow(pow(f, 2**30, g), 2**30, g)
         assert pow(R_gen, 2**60, g) == pow(pow(R_gen, 2**30, g), 2**30, g)
 
-        # Check other typechecks for pow_mod 
+        # Check other typechecks for pow_mod
         assert raises(lambda: pow(f, -2, g), ValueError)
         assert raises(lambda: pow(f, 1, "A"), TypeError)
         assert raises(lambda: pow(f, "A", g), TypeError)
@@ -2756,7 +2756,7 @@ def test_polys():
         assert P([1, 1]) ** 2 == P([1, 2, 1])
         assert raises(lambda: P([1, 1]) ** -1, ValueError)
         assert raises(lambda: P([1, 1]) ** None, TypeError)
-        
+
         # XXX: Not sure what this should do in general:
         p = P([1, 1])
         mod = P([1, 1])
@@ -2816,32 +2816,32 @@ def test_polys():
 
 def _all_mpolys():
     return [
-        (flint.fmpz_mpoly, flint.fmpz_mpoly_ctx.get_context, flint.fmpz, False, flint.fmpz(0)),
-        (flint.fmpq_mpoly, flint.fmpq_mpoly_ctx.get_context, flint.fmpq, True, flint.fmpz(0)),
+        (flint.fmpz_mpoly, flint.fmpz_mpoly_ctx.get, flint.fmpz, False, flint.fmpz(0)),
+        (flint.fmpq_mpoly, flint.fmpq_mpoly_ctx.get, flint.fmpq, True, flint.fmpz(0)),
         (
             flint.fmpz_mod_mpoly,
-            lambda *args, **kwargs: flint.fmpz_mod_mpoly_ctx.get_context(*args, **kwargs, modulus=101),
+            lambda *args, **kwargs: flint.fmpz_mod_mpoly_ctx.get(*args, **kwargs, modulus=101),
             lambda x: flint.fmpz_mod(x, flint.fmpz_mod_ctx(101)),
             True,
             flint.fmpz(101),
         ),
         (
             flint.fmpz_mod_mpoly,
-            lambda *args, **kwargs: flint.fmpz_mod_mpoly_ctx.get_context(*args, **kwargs, modulus=100),
+            lambda *args, **kwargs: flint.fmpz_mod_mpoly_ctx.get(*args, **kwargs, modulus=100),
             lambda x: flint.fmpz_mod(x, flint.fmpz_mod_ctx(100)),
             False,
             flint.fmpz(100),
         ),
         (
             flint.nmod_mpoly,
-            lambda *args, **kwargs: flint.nmod_mpoly_ctx.get_context(*args, **kwargs, modulus=101),
+            lambda *args, **kwargs: flint.nmod_mpoly_ctx.get(*args, **kwargs, modulus=101),
             lambda x: flint.nmod(x, 101),
             True,
             flint.fmpz(101),
         ),
         (
             flint.nmod_mpoly,
-            lambda *args, **kwargs: flint.nmod_mpoly_ctx.get_context(*args, **kwargs, modulus=100),
+            lambda *args, **kwargs: flint.nmod_mpoly_ctx.get(*args, **kwargs, modulus=100),
             lambda x: flint.nmod(x, 100),
             False,
             flint.fmpz(100),
@@ -2944,7 +2944,7 @@ def test_mpolys():
         assert P({(0, 1): 3}, ctx=ctx) == ctx.from_dict({(0, 1): 3})
 
         if P is flint.fmpq_mpoly:
-            ctx_z = flint.fmpz_mpoly_ctx.get_context((("x", 2),))
+            ctx_z = flint.fmpz_mpoly_ctx.get((("x", 2),))
             assert quick_poly() == P(ctx_z.from_dict({(0, 0): 1, (0, 1): 2, (1, 0): 3, (2, 2): 4}))
             assert P(ctx_z.from_dict({(0, 0): 1}), ctx=ctx) == P({(0, 0): 1}, ctx=ctx)
 
@@ -3314,8 +3314,8 @@ def test_fmpz_mpoly_vec():
     for context, mpoly_vec in _all_mpoly_vecs():
         has_groebner_functions = mpoly_vec is flint.fmpz_mpoly_vec
 
-        ctx = context.get_context((("x", 2),))
-        ctx1 = context.get_context((("x", 4),))
+        ctx = context.get((("x", 2),))
+        ctx1 = context.get((("x", 4),))
         x, y = ctx.gens()
 
         vec = mpoly_vec(3, ctx)
@@ -3344,7 +3344,7 @@ def test_fmpz_mpoly_vec():
         assert raises(lambda: vec.__setitem__(0, ctx1.from_dict({})), IncompatibleContextError)
 
         if has_groebner_functions:
-            ctx = context.get_context(("x", "y", "z"))
+            ctx = context.get(("x", "y", "z"))
 
             # Examples here cannibalised from
             # https://en.wikipedia.org/wiki/Gr%C3%B6bner_basis#Example_and_counterexample
@@ -3407,8 +3407,8 @@ def _all_polys_mpolys():
         ))
         yield P, S, [x, y], is_field, characteristic
 
-    for P, get_context, S, is_field, characteristic in _all_mpolys():
-        ctx = get_context(("x", "y"))
+    for P, get, S, is_field, characteristic in _all_mpolys():
+        ctx = get(("x", "y"))
         x, y = ctx.gens()
         assert isinstance(x, (
             flint.fmpz_mpoly,
@@ -4159,7 +4159,7 @@ def test_fq_default():
 
     # p must be prime
     assert raises(lambda: flint.fq_default_ctx(10), ValueError)
-    
+
     # degree must be positive
     assert raises(lambda: flint.fq_default_ctx(11, -1), ValueError)
 

--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -2861,6 +2861,7 @@ def test_mpolys():
 
         ctx = get_context((("x", 2),))
 
+        assert raises(lambda : ctx.__class__("x", flint.Ordering.lex), RuntimeError)
         assert raises(lambda: get_context((("x", 2),), ordering="bad"), ValueError)
         assert raises(lambda: get_context((("x", -1),)), ValueError)
         assert raises(lambda: ctx.constant("bad"), TypeError)

--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -2859,14 +2859,10 @@ def test_mpolys():
         # division is exact or not.
         composite_characteristic = characteristic != 0 and not characteristic.is_prime()
 
-        ctx = get_context(nvars=2)
+        ctx = get_context((("x", 2),))
 
-        assert raises(lambda: get_context(nvars=2, ordering="bad"), TypeError)
-        assert raises(lambda: get_context(nvars=-1), ValueError)
-        if ctx.__class__ is flint.fmpz_mod_mpoly_ctx or ctx.__class__ is flint.nmod_mpoly_ctx:
-            assert raises(lambda: ctx.__class__(-1, flint.Ordering.lex, [], 4), ValueError)
-        else:
-            assert raises(lambda: ctx.__class__(-1, flint.Ordering.lex, []), ValueError)
+        assert raises(lambda: get_context((("x", 2),), ordering="bad"), ValueError)
+        assert raises(lambda: get_context((("x", -1),)), ValueError)
         assert raises(lambda: ctx.constant("bad"), TypeError)
         assert raises(lambda: ctx.from_dict("bad"), ValueError)
         assert raises(lambda: ctx.from_dict({(0, 0): "bad"}), TypeError)
@@ -2875,7 +2871,7 @@ def test_mpolys():
         assert raises(lambda: ctx.gen(-1), IndexError)
         assert raises(lambda: ctx.gen(10), IndexError)
 
-        assert raises(lambda: P(val=get_context(nvars=1).constant(0), ctx=ctx), IncompatibleContextError)
+        assert raises(lambda: P(val=get_context(("x",)).constant(0), ctx=ctx), IncompatibleContextError)
         assert raises(lambda: P(val={}, ctx=None), ValueError)
         assert raises(lambda: P(val={"bad": 1}, ctx=None), ValueError)
         assert raises(lambda: P(val="1", ctx=None), ValueError)
@@ -2894,10 +2890,10 @@ def test_mpolys():
         assert ctx.nvars() == 2
         assert ctx.ordering() == flint.Ordering.lex
 
-        ctx1 = get_context(4)
+        ctx1 = get_context((("x", 4),))
         assert [ctx1.name(i) for i in range(4)] == ['x0', 'x1', 'x2', 'x3']
         for order in list(flint.Ordering):
-            ctx1 = get_context(4, order)
+            ctx1 = get_context((("x", 4),), ordering=order)
             assert ctx1.ordering() == order
 
         assert ctx.constant(1) == mpoly({(0, 0): 1}) == P(1, ctx=ctx)
@@ -2948,7 +2944,7 @@ def test_mpolys():
         assert P({(0, 1): 3}, ctx=ctx) == ctx.from_dict({(0, 1): 3})
 
         if P is flint.fmpq_mpoly:
-            ctx_z = flint.fmpz_mpoly_ctx.get_context(2)
+            ctx_z = flint.fmpz_mpoly_ctx.get_context((("x", 2),))
             assert quick_poly() == P(ctx_z.from_dict({(0, 0): 1, (0, 1): 2, (1, 0): 3, (2, 2): 4}))
             assert P(ctx_z.from_dict({(0, 0): 1}), ctx=ctx) == P({(0, 0): 1}, ctx=ctx)
 
@@ -2997,8 +2993,8 @@ def test_mpolys():
 
         assert raises(lambda: p.__setitem__((2, 1), None), TypeError)
 
-        assert P(ctx=ctx).repr() == f"{ctx.__class__.__name__}(2, '<Ordering.lex: 0>', ('x0', 'x1')).from_dict({{}})"
-        assert P(1, ctx=ctx).repr() == f"{ctx.__class__.__name__}(2, '<Ordering.lex: 0>', ('x0', 'x1')).from_dict({{(0, 0): 1}})"
+        assert P(ctx=ctx).repr() == f"{ctx.__class__.__name__}(2, '<Ordering.lex: 'lex'>', ('x0', 'x1')).from_dict({{}})"
+        assert P(1, ctx=ctx).repr() == f"{ctx.__class__.__name__}(2, '<Ordering.lex: 'lex'>', ('x0', 'x1')).from_dict({{(0, 0): 1}})"
         assert str(quick_poly()) == repr(quick_poly()) == '4*x0^2*x1^2 + 3*x0 + 2*x1 + 1'
 
         assert p.monomial(0) == (2, 2)
@@ -3039,7 +3035,7 @@ def test_mpolys():
         assert raises(lambda: p.subs({"a": 1}), ValueError)
         assert raises(lambda: p.subs({"x0": 0, "x1": 1, "x2": 2}), ValueError)
 
-        no_gens_ctx = get_context(0)
+        no_gens_ctx = get_context(tuple())
         no_gens_p = P("2", no_gens_ctx)
         assert no_gens_p.compose(ctx=ctx1).context() is ctx1
         assert raises(lambda: no_gens_p.compose(), ValueError)
@@ -3318,8 +3314,8 @@ def test_fmpz_mpoly_vec():
     for context, mpoly_vec in _all_mpoly_vecs():
         has_groebner_functions = mpoly_vec is flint.fmpz_mpoly_vec
 
-        ctx = context.get_context(nvars=2)
-        ctx1 = context.get_context(nvars=4)
+        ctx = context.get_context((("x", 2),))
+        ctx1 = context.get_context((("x", 4),))
         x, y = ctx.gens()
 
         vec = mpoly_vec(3, ctx)
@@ -3348,7 +3344,7 @@ def test_fmpz_mpoly_vec():
         assert raises(lambda: vec.__setitem__(0, ctx1.from_dict({})), IncompatibleContextError)
 
         if has_groebner_functions:
-            ctx = context.get_context(3, flint.Ordering.lex, nametup=('x', 'y', 'z'))
+            ctx = context.get_context(("x", "y", "z"))
 
             # Examples here cannibalised from
             # https://en.wikipedia.org/wiki/Gr%C3%B6bner_basis#Example_and_counterexample
@@ -3412,7 +3408,7 @@ def _all_polys_mpolys():
         yield P, S, [x, y], is_field, characteristic
 
     for P, get_context, S, is_field, characteristic in _all_mpolys():
-        ctx = get_context(2, flint.Ordering.lex, nametup=("x", "y"))
+        ctx = get_context(("x", "y"))
         x, y = ctx.gens()
         assert isinstance(x, (
             flint.fmpz_mpoly,

--- a/src/flint/types/fmpq_mpoly.pyx
+++ b/src/flint/types/fmpq_mpoly.pyx
@@ -89,9 +89,8 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
     """
     A class for storing the polynomial context
 
-    :param nvars: The number of variables in the ring
-    :param ordering:  The term order for the ring
     :param names:  A tuple containing the names of the variables of the ring.
+    :param ordering:  The term order for the ring.
 
     Do not construct one of these directly, use ``fmpz_mpoly_ctx.get``.
     """

--- a/src/flint/types/fmpq_mpoly.pyx
+++ b/src/flint/types/fmpq_mpoly.pyx
@@ -102,7 +102,7 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
         fmpq_mpoly_ctx_init(self.val, nvars, ordering_py_to_c(ordering))
         super().__init__(nvars, names)
 
-    def any_as_scalar(self, other):
+    def _any_as_scalar(self, other):
         if isinstance(other, int):
             return any_as_fmpq(other)
         elif typecheck(other, fmpz):
@@ -114,8 +114,8 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
         else:
             return NotImplemented
 
-    def scalar_as_mpoly(self, other: fmpq):
-        # non-fmpq scalars should first be converted via self.any_as_scalar
+    def _scalar_as_mpoly(self, other: fmpq):
+        # non-fmpq scalars should first be converted via self._any_as_scalar
         return self.constant(<fmpq>other)
 
     def nvars(self):

--- a/src/flint/types/fmpq_mpoly.pyx
+++ b/src/flint/types/fmpq_mpoly.pyx
@@ -122,8 +122,7 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
         """
         Return the number of variables in the context
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(4, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 4), 'lex')
             >>> ctx.nvars()
             4
         """
@@ -133,10 +132,9 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
         """
         Return the term order of the context object.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(4, Ordering.deglex, 'w')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('w', 4), 'deglex')
             >>> ctx.ordering()
-            <Ordering.deglex: 1>
+            <Ordering.deglex: 'deglex'>
         """
         return ordering_c_to_py(self.val.zctx.minfo.ord)
 
@@ -144,8 +142,7 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
         """
         Return the ``i`` th generator of the polynomial ring
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(3, Ordering.degrevlex, 'z')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('z', 3), 'degrevlex')
             >>> ctx.gen(1)
             z1
         """
@@ -175,8 +172,7 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
         The dictionary's keys are tuples of ints (or anything that implicitly converts
         to fmpz) representing exponents, and corresponding coefficient values of fmpq.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x,y')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> ctx.from_dict({(1,0):2, (1,1):3, (0,1):1})
             3*x*y + 2*x + y
         """
@@ -306,8 +302,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Always returns a value, missing keys will return ``0``.
         Negative exponents are made positive.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1]
             3
@@ -332,8 +327,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Will always set a value, missing keys will create a new term.
         Negative exponents are made positive.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1] = 20
             >>> p
@@ -511,8 +505,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the exponent vectors of each term as a tuple of fmpz.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.monoms()
             [(1, 1), (1, 0), (0, 1), (0, 0)]
@@ -533,8 +526,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the coefficients of each term as a fmpq.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.coeffs()
             [4, 2, 3, 1]
@@ -556,8 +548,7 @@ cdef class fmpq_mpoly(flint_mpoly):
     #     """
     #     Return the terms of this polynomial as a list of fmpq_mpolys.
 
-    #         >>> from flint import Ordering
-    #         >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+    #         >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
     #         >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
     #         >>> f.terms()
     #         [4*x0*x1, 2*x0, 3*x1, 1]
@@ -580,8 +571,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Partial evaluate this polynomial with select constants. Keys must be generator names or generator indices,
         all values must be fmpq.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.subs({"x1": 0})
             2*x0 + 1
@@ -610,9 +600,8 @@ cdef class fmpq_mpoly(flint_mpoly):
         Compose this polynomial with other fmpq_mpolys. All arguments must share the same context, it may different
         from this polynomials context.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(1, Ordering.lex, 'x')
-            >>> ctx1 = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'y')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x',), 'lex')
+            >>> ctx1 = fmpq_mpoly_ctx.get_context(('y', 2), 'lex')
             >>> f = ctx.from_dict({(2,): 1})
             >>> g = ctx1.from_dict({(1, 0): 1, (0, 1): 1})
             >>> f
@@ -660,8 +649,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the context object for this polynomials.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2})
             >>> ctx is p.context()
             True
@@ -672,8 +660,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the coefficient at index ``i``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.coefficient(1)
             2
@@ -690,8 +677,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the exponent vector at index ``i`` as a tuple.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.monomial(1)
             (0, 1)
@@ -709,8 +695,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return a dictionary of variable name to degree.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(4, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 4), 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.degrees()
             (1, 2, 3, 0)
@@ -726,8 +711,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the total degree.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(4, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 4), 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.total_degree()
             3
@@ -740,8 +724,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Leading coefficient in the monomial ordering.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx(2, Ordering.lex, ['x', 'y'])
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> p = 2*x*y + 3*x + 4*y**2 + 5
             >>> p
@@ -770,8 +753,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the gcd of self and other.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> g = ctx.from_dict({(0, 1): 2, (1, 0): 2})
             >>> (f * g).gcd(f)
@@ -792,8 +774,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Return the GCD of the terms of ``self``. If ``self`` is zero, then the result will
         be zero, otherwise it will be a monomial with positive coefficient.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = 3 * x0**2 * x1 + 6 * x0 * x1
             >>> f.term_content()
@@ -807,8 +788,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the resultant of ``self`` and ``other`` with respect to variable ``var``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = x0**2 * x1 + x0 * x1
             >>> g = x0 + x1
@@ -834,8 +814,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the discriminant of ``self`` with respect to variable ``var``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = (x0 + x1)**2 + 1
             >>> f.discriminant('x1')
@@ -856,8 +835,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the square root of self.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> (f * f).sqrt()
             4*x0*x1 + 1
@@ -876,9 +854,8 @@ cdef class fmpq_mpoly(flint_mpoly):
         (c, factors) where c is the content of the coefficients and
         factors is a list of (poly, exp) pairs.
 
-            >>> from flint import Ordering
             >>> Zm = fmpq_mpoly
-            >>> ctx = fmpq_mpoly_ctx.get_context(3, Ordering.lex, 'x,y,z')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y', 'z'), 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*z + 3*x + 3*z + 3", ctx)
             >>> (p1 * p2).factor()
@@ -915,9 +892,8 @@ cdef class fmpq_mpoly(flint_mpoly):
         (c, factors) where c is the content of the coefficients and
         factors is a list of (poly, exp) pairs.
 
-            >>> from flint import Ordering
             >>> Zm = fmpq_mpoly
-            >>> ctx = fmpq_mpoly_ctx.get_context(3, Ordering.lex, 'x,y,z')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y', 'z'), 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*y + 3*x + 3*y + 3", ctx)
             >>> (p1 * p2).factor_squarefree()
@@ -954,8 +930,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         The argument can either be the variable as a string, or the index of the
         variable in the context.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -979,8 +954,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Return the integral of this polynomial with respect to the provided variable The argument can either be the
         variable as a string, or the index of the variable in the context.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -1004,8 +978,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Compute the inflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^N)``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x + y + 1
             >>> f.inflate([2, 3])
@@ -1033,8 +1006,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Compute the deflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^(1/N))``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> f.deflate([2, 3])
@@ -1058,8 +1030,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Compute the deflation of ``self``, that is ``p(X^(1/N))`` for maximal N.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 * y**2 + x * y**2
             >>> q, N = f.deflation()
@@ -1091,8 +1062,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         = m * q(X^N)`` for maximal N. The returned monomial allows the undo-ing of the
         deflation.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> fd, N, m = f.deflation_monom()
@@ -1123,8 +1093,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         exponents. It is the exponent vector of the monomial returned by
         ``deflation_monom``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpq_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> N, I = f.deflation_index()

--- a/src/flint/types/fmpq_mpoly.pyx
+++ b/src/flint/types/fmpq_mpoly.pyx
@@ -98,9 +98,9 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
 
     _ctx_cache = _fmpq_mpoly_ctx_cache
 
-    def __init__(self, slong nvars, ordering, names):
-        fmpq_mpoly_ctx_init(self.val, nvars, ordering_py_to_c(ordering))
-        super().__init__(nvars, names)
+    def __init__(self, names, ordering):
+        super().__init__(names)
+        fmpq_mpoly_ctx_init(self.val, len(names), ordering_py_to_c(ordering))
 
     def _any_as_scalar(self, other):
         if isinstance(other, int):

--- a/src/flint/types/fmpq_mpoly.pyx
+++ b/src/flint/types/fmpq_mpoly.pyx
@@ -93,7 +93,7 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
     :param ordering:  The term order for the ring
     :param names:  A tuple containing the names of the variables of the ring.
 
-    Do not construct one of these directly, use ``fmpz_mpoly_ctx.get_context``.
+    Do not construct one of these directly, use ``fmpz_mpoly_ctx.get``.
     """
 
     _ctx_cache = _fmpq_mpoly_ctx_cache
@@ -122,7 +122,7 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
         """
         Return the number of variables in the context
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 4), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 4), 'lex')
             >>> ctx.nvars()
             4
         """
@@ -132,7 +132,7 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
         """
         Return the term order of the context object.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('w', 4), 'deglex')
+            >>> ctx = fmpq_mpoly_ctx.get(('w', 4), 'deglex')
             >>> ctx.ordering()
             <Ordering.deglex: 'deglex'>
         """
@@ -142,7 +142,7 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
         """
         Return the ``i`` th generator of the polynomial ring
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('z', 3), 'degrevlex')
+            >>> ctx = fmpq_mpoly_ctx.get(('z', 3), 'degrevlex')
             >>> ctx.gen(1)
             z1
         """
@@ -172,7 +172,7 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
         The dictionary's keys are tuples of ints (or anything that implicitly converts
         to fmpz) representing exponents, and corresponding coefficient values of fmpq.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> ctx.from_dict({(1,0):2, (1,1):3, (0,1):1})
             3*x*y + 2*x + y
         """
@@ -302,7 +302,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Always returns a value, missing keys will return ``0``.
         Negative exponents are made positive.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1]
             3
@@ -327,7 +327,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Will always set a value, missing keys will create a new term.
         Negative exponents are made positive.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1] = 20
             >>> p
@@ -505,7 +505,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the exponent vectors of each term as a tuple of fmpz.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.monoms()
             [(1, 1), (1, 0), (0, 1), (0, 0)]
@@ -526,7 +526,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the coefficients of each term as a fmpq.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.coeffs()
             [4, 2, 3, 1]
@@ -548,7 +548,7 @@ cdef class fmpq_mpoly(flint_mpoly):
     #     """
     #     Return the terms of this polynomial as a list of fmpq_mpolys.
 
-    #         >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+    #         >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
     #         >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
     #         >>> f.terms()
     #         [4*x0*x1, 2*x0, 3*x1, 1]
@@ -571,7 +571,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Partial evaluate this polynomial with select constants. Keys must be generator names or generator indices,
         all values must be fmpq.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.subs({"x1": 0})
             2*x0 + 1
@@ -600,8 +600,8 @@ cdef class fmpq_mpoly(flint_mpoly):
         Compose this polynomial with other fmpq_mpolys. All arguments must share the same context, it may different
         from this polynomials context.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x',), 'lex')
-            >>> ctx1 = fmpq_mpoly_ctx.get_context(('y', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x',), 'lex')
+            >>> ctx1 = fmpq_mpoly_ctx.get(('y', 2), 'lex')
             >>> f = ctx.from_dict({(2,): 1})
             >>> g = ctx1.from_dict({(1, 0): 1, (0, 1): 1})
             >>> f
@@ -649,7 +649,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the context object for this polynomials.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2})
             >>> ctx is p.context()
             True
@@ -660,7 +660,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the coefficient at index ``i``.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.coefficient(1)
             2
@@ -677,7 +677,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the exponent vector at index ``i`` as a tuple.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.monomial(1)
             (0, 1)
@@ -695,7 +695,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return a dictionary of variable name to degree.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 4), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 4), 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.degrees()
             (1, 2, 3, 0)
@@ -711,7 +711,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the total degree.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 4), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 4), 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.total_degree()
             3
@@ -724,7 +724,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Leading coefficient in the monomial ordering.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> p = 2*x*y + 3*x + 4*y**2 + 5
             >>> p
@@ -753,7 +753,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the gcd of self and other.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> g = ctx.from_dict({(0, 1): 2, (1, 0): 2})
             >>> (f * g).gcd(f)
@@ -774,7 +774,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Return the GCD of the terms of ``self``. If ``self`` is zero, then the result will
         be zero, otherwise it will be a monomial with positive coefficient.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = 3 * x0**2 * x1 + 6 * x0 * x1
             >>> f.term_content()
@@ -788,7 +788,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the resultant of ``self`` and ``other`` with respect to variable ``var``.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = x0**2 * x1 + x0 * x1
             >>> g = x0 + x1
@@ -814,7 +814,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the discriminant of ``self`` with respect to variable ``var``.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = (x0 + x1)**2 + 1
             >>> f.discriminant('x1')
@@ -835,7 +835,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Return the square root of self.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> (f * f).sqrt()
             4*x0*x1 + 1
@@ -855,7 +855,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         factors is a list of (poly, exp) pairs.
 
             >>> Zm = fmpq_mpoly
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y', 'z'), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 'y', 'z'), 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*z + 3*x + 3*z + 3", ctx)
             >>> (p1 * p2).factor()
@@ -893,7 +893,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         factors is a list of (poly, exp) pairs.
 
             >>> Zm = fmpq_mpoly
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y', 'z'), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 'y', 'z'), 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*y + 3*x + 3*y + 3", ctx)
             >>> (p1 * p2).factor_squarefree()
@@ -930,7 +930,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         The argument can either be the variable as a string, or the index of the
         variable in the context.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -954,7 +954,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Return the integral of this polynomial with respect to the provided variable The argument can either be the
         variable as a string, or the index of the variable in the context.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -978,7 +978,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Compute the inflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^N)``.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x + y + 1
             >>> f.inflate([2, 3])
@@ -1006,7 +1006,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         Compute the deflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^(1/N))``.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> f.deflate([2, 3])
@@ -1030,7 +1030,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         """
         Compute the deflation of ``self``, that is ``p(X^(1/N))`` for maximal N.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 * y**2 + x * y**2
             >>> q, N = f.deflation()
@@ -1062,7 +1062,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         = m * q(X^N)`` for maximal N. The returned monomial allows the undo-ing of the
         deflation.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> fd, N, m = f.deflation_monom()
@@ -1093,7 +1093,7 @@ cdef class fmpq_mpoly(flint_mpoly):
         exponents. It is the exponent vector of the monomial returned by
         ``deflation_monom``.
 
-            >>> ctx = fmpq_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpq_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> N, I = f.deflation_index()

--- a/src/flint/types/fmpq_mpoly.pyx
+++ b/src/flint/types/fmpq_mpoly.pyx
@@ -97,9 +97,13 @@ cdef class fmpq_mpoly_ctx(flint_mpoly_context):
 
     _ctx_cache = _fmpq_mpoly_ctx_cache
 
-    def __init__(self, names, ordering):
-        super().__init__(names)
+    @classmethod
+    def _new_(cls, names, ordering):
+        cdef fmpq_mpoly_ctx self = cls.__new__(cls)
+        super()._new_(self, names)
         fmpq_mpoly_ctx_init(self.val, len(names), ordering_py_to_c(ordering))
+
+        return self
 
     def _any_as_scalar(self, other):
         if isinstance(other, int):

--- a/src/flint/types/fmpz_mod_mpoly.pxd
+++ b/src/flint/types/fmpz_mod_mpoly.pxd
@@ -1,4 +1,4 @@
-from flint.flint_base.flint_base cimport flint_mpoly, flint_mpoly_context
+from flint.flint_base.flint_base cimport flint_mpoly, flint_mod_mpoly_context
 
 from flint.flintlib.functions.fmpz_mod_mpoly cimport (
     fmpz_mod_mpoly_ctx_t,
@@ -21,9 +21,8 @@ cdef inline fmpz_mod_mpoly create_fmpz_mod_mpoly(fmpz_mod_mpoly_ctx ctx):
     var._init = True
     return var
 
-cdef class fmpz_mod_mpoly_ctx(flint_mpoly_context):
+cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
     cdef fmpz_mod_mpoly_ctx_t val
-    cdef readonly object __prime_modulus
 
 cdef class fmpz_mod_mpoly(flint_mpoly):
     cdef fmpz_mod_mpoly_t val

--- a/src/flint/types/fmpz_mod_mpoly.pyx
+++ b/src/flint/types/fmpz_mod_mpoly.pyx
@@ -84,7 +84,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
     :param ordering:  The term order for the ring
     :param names:  A tuple containing the names of the variables of the ring.
 
-    Do not construct one of these directly, use ``fmpz_mod_mpoly_ctx.get_context``.
+    Do not construct one of these directly, use ``fmpz_mod_mpoly_ctx.get``.
     """
 
     _ctx_cache = _fmpz_mod_mpoly_ctx_cache
@@ -125,7 +125,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the number of variables in the context
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 4), 11, 'lex')
             >>> ctx.nvars()
             4
         """
@@ -135,7 +135,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the term order of the context object.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('w', 4), 11, 'deglex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('w', 4), 11, 'deglex')
             >>> ctx.ordering()
             <Ordering.deglex: 'deglex'>
         """
@@ -145,7 +145,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the modulus of the context object.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('w', 4), 2, 'deglex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('w', 4), 2, 'deglex')
             >>> ctx.modulus()
             2
 
@@ -158,7 +158,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the ``i`` th generator of the polynomial ring
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('z', 3), 11, 'degrevlex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('z', 3), 11, 'degrevlex')
             >>> ctx.gen(1)
             z1
         """
@@ -188,7 +188,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         The dictionary's keys are tuples of ints (or anything that implicitly converts
         to fmpz) representing exponents, and corresponding values of fmpz.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> ctx.from_dict({(1,0):2, (1,1):3, (0,1):1})
             3*x*y + 2*x + y
         """
@@ -321,7 +321,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Always returns a value, missing keys will return ``0``.
         Negative exponents are made positive.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1]
             3
@@ -346,7 +346,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Will always set a value, missing keys will create a new term.
         Negative exponents are made positive.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1] = 20
             >>> p
@@ -513,7 +513,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the exponent vectors of each term as a tuple of fmpz.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.monoms()
             [(1, 1), (1, 0), (0, 1), (0, 0)]
@@ -534,7 +534,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the coefficients of each term as a fmpz
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.coeffs()
             [4, 2, 3, 1]
@@ -556,7 +556,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
     #     """
     #     Return the terms of this polynomial as a list of fmpz_mod_mpolys.
 
-    #         >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+    #         >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
     #         >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
     #         >>> f.terms()
     #         [4*x0*x1, 2*x0, 3*x1, 1]
@@ -579,7 +579,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Partial evaluate this polynomial with select constants. Keys must be generator names or generator indices,
         all values must be fmpz.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.subs({"x1": 0})
             2*x0 + 1
@@ -607,8 +607,8 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Compose this polynomial with other fmpz_mod_mpolys. All arguments must share the same context, it may different
         from this polynomials context.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x',), 11, 'lex')
-            >>> ctx1 = fmpz_mod_mpoly_ctx.get_context(('y', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x',), 11, 'lex')
+            >>> ctx1 = fmpz_mod_mpoly_ctx.get(('y', 2), 11, 'lex')
             >>> f = ctx.from_dict({(2,): 1})
             >>> g = ctx1.from_dict({(1, 0): 1, (0, 1): 1})
             >>> f
@@ -654,7 +654,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the context object for this polynomials.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2})
             >>> ctx is p.context()
             True
@@ -665,7 +665,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the coefficient at index ``i``.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.coefficient(1)
             2
@@ -682,7 +682,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the exponent vector at index ``i`` as a tuple.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.monomial(1)
             (0, 1)
@@ -700,7 +700,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return a dictionary of variable name to degree.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 4), 11, 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.degrees()
             (1, 2, 3, 0)
@@ -716,7 +716,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the total degree.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 4), 11, 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.total_degree()
             3
@@ -729,7 +729,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Leading coefficient in the monomial ordering.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> p = 2*x*y + 3*x + 4*y**2 + 5
             >>> p
@@ -757,7 +757,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the gcd of self and other.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> g = ctx.from_dict({(0, 1): 2, (1, 0): 2})
             >>> (f * g).gcd(f)
@@ -779,7 +779,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Return the GCD of the terms of ``self``. If ``self`` is zero, then the result will
         be zero, otherwise it will be a monomial with positive coefficient.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = 3 * x0**2 * x1 + 6 * x0 * x1
             >>> f.term_content()
@@ -794,7 +794,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the resultant of ``self`` and ``other`` with respect to variable ``var``.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = x0**2 * x1 + x0 * x1
             >>> g = x0 + x1
@@ -820,7 +820,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the discriminant of ``self`` with respect to variable ``var``.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = (x0 + x1)**2 + 1
             >>> f.discriminant('x1')
@@ -841,7 +841,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the square root of self.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> (f * f).sqrt()
             4*x0*x1 + 1
@@ -864,7 +864,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         factors is a list of (poly, exp) pairs.
 
             >>> Zm = fmpz_mod_mpoly
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y', 'z'), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 'y', 'z'), 11, 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*z + 3*x + 3*z + 3", ctx)
             >>> (p1 * p2).factor()
@@ -906,7 +906,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         factors is a list of (poly, exp) pairs.
 
             >>> Zm = fmpz_mod_mpoly
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y', 'z'), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 'y', 'z'), 11, 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*y + 3*x + 3*y + 3", ctx)
             >>> (p1 * p2).factor_squarefree()
@@ -975,7 +975,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         The argument can either be the variable as a string, or the index of the
         variable in the context.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -999,7 +999,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Compute the inflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^N)``.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x + y + 1
             >>> f.inflate([2, 3])
@@ -1026,7 +1026,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Compute the deflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^(1/N))``.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> f.deflate([2, 3])
@@ -1050,7 +1050,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Compute the deflation of ``self``, that is ``p(X^(1/N))`` for maximal
         N. Returns ``q, N`` such that ``self == q.inflate(N)``.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 * y**2 + x * y**2
             >>> q, N = f.deflation()
@@ -1081,7 +1081,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         = m * q(X^N)`` for maximal N. The returned monomial allows the undo-ing of the
         deflation.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> fd, N, m = f.deflation_monom()
@@ -1111,7 +1111,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         exponents. It is the exponent vector of the monomial returned by
         ``deflation_monom``.
 
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = fmpz_mod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> N, I = f.deflation_index()

--- a/src/flint/types/fmpz_mod_mpoly.pyx
+++ b/src/flint/types/fmpz_mod_mpoly.pyx
@@ -80,9 +80,9 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
     """
     A class for storing the polynomial context
 
-    :param nvars: The number of variables in the ring
-    :param ordering:  The term order for the ring
     :param names:  A tuple containing the names of the variables of the ring.
+    :param ordering:  The term order for the ring.
+    :param modulus:  The modulus for the ring.
 
     Do not construct one of these directly, use ``fmpz_mod_mpoly_ctx.get``.
     """

--- a/src/flint/types/fmpz_mod_mpoly.pyx
+++ b/src/flint/types/fmpz_mod_mpoly.pyx
@@ -125,8 +125,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the number of variables in the context
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(4, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
             >>> ctx.nvars()
             4
         """
@@ -136,10 +135,9 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the term order of the context object.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(4, Ordering.deglex, 11, 'w')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('w', 4), 11, 'deglex')
             >>> ctx.ordering()
-            <Ordering.deglex: 1>
+            <Ordering.deglex: 'deglex'>
         """
         return ordering_c_to_py(self.val.minfo.ord)
 
@@ -147,8 +145,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the modulus of the context object.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(4, Ordering.deglex, 2, 'w')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('w', 4), 2, 'deglex')
             >>> ctx.modulus()
             2
 
@@ -161,8 +158,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the ``i`` th generator of the polynomial ring
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(3, Ordering.degrevlex, 11, 'z')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('z', 3), 11, 'degrevlex')
             >>> ctx.gen(1)
             z1
         """
@@ -192,8 +188,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         The dictionary's keys are tuples of ints (or anything that implicitly converts
         to fmpz) representing exponents, and corresponding values of fmpz.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x,y')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> ctx.from_dict({(1,0):2, (1,1):3, (0,1):1})
             3*x*y + 2*x + y
         """
@@ -326,8 +321,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Always returns a value, missing keys will return ``0``.
         Negative exponents are made positive.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1]
             3
@@ -352,8 +346,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Will always set a value, missing keys will create a new term.
         Negative exponents are made positive.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1] = 20
             >>> p
@@ -520,8 +513,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the exponent vectors of each term as a tuple of fmpz.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.monoms()
             [(1, 1), (1, 0), (0, 1), (0, 0)]
@@ -542,8 +534,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the coefficients of each term as a fmpz
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.coeffs()
             [4, 2, 3, 1]
@@ -565,8 +556,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
     #     """
     #     Return the terms of this polynomial as a list of fmpz_mod_mpolys.
 
-    #         >>> from flint import Ordering
-    #         >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+    #         >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
     #         >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
     #         >>> f.terms()
     #         [4*x0*x1, 2*x0, 3*x1, 1]
@@ -589,8 +579,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Partial evaluate this polynomial with select constants. Keys must be generator names or generator indices,
         all values must be fmpz.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.subs({"x1": 0})
             2*x0 + 1
@@ -618,9 +607,8 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Compose this polynomial with other fmpz_mod_mpolys. All arguments must share the same context, it may different
         from this polynomials context.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(1, Ordering.lex, 11, 'x')
-            >>> ctx1 = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'y')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x',), 11, 'lex')
+            >>> ctx1 = fmpz_mod_mpoly_ctx.get_context(('y', 2), 11, 'lex')
             >>> f = ctx.from_dict({(2,): 1})
             >>> g = ctx1.from_dict({(1, 0): 1, (0, 1): 1})
             >>> f
@@ -666,8 +654,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the context object for this polynomials.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2})
             >>> ctx is p.context()
             True
@@ -678,8 +665,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the coefficient at index ``i``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.coefficient(1)
             2
@@ -696,8 +682,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the exponent vector at index ``i`` as a tuple.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.monomial(1)
             (0, 1)
@@ -715,8 +700,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return a dictionary of variable name to degree.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(4, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.degrees()
             (1, 2, 3, 0)
@@ -732,8 +716,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the total degree.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(4, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.total_degree()
             3
@@ -746,8 +729,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Leading coefficient in the monomial ordering.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx(2, Ordering.lex, ['x', 'y'], 11)
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> p = 2*x*y + 3*x + 4*y**2 + 5
             >>> p
@@ -775,8 +757,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the gcd of self and other.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> g = ctx.from_dict({(0, 1): 2, (1, 0): 2})
             >>> (f * g).gcd(f)
@@ -798,8 +779,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Return the GCD of the terms of ``self``. If ``self`` is zero, then the result will
         be zero, otherwise it will be a monomial with positive coefficient.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = 3 * x0**2 * x1 + 6 * x0 * x1
             >>> f.term_content()
@@ -814,8 +794,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the resultant of ``self`` and ``other`` with respect to variable ``var``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = x0**2 * x1 + x0 * x1
             >>> g = x0 + x1
@@ -841,8 +820,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the discriminant of ``self`` with respect to variable ``var``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = (x0 + x1)**2 + 1
             >>> f.discriminant('x1')
@@ -863,8 +841,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         """
         Return the square root of self.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> (f * f).sqrt()
             4*x0*x1 + 1
@@ -886,9 +863,8 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         (c, factors) where c is the content of the coefficients and
         factors is a list of (poly, exp) pairs.
 
-            >>> from flint import Ordering
             >>> Zm = fmpz_mod_mpoly
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(3, Ordering.lex, 11, 'x,y,z')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y', 'z'), 11, 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*z + 3*x + 3*z + 3", ctx)
             >>> (p1 * p2).factor()
@@ -929,9 +905,8 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         (c, factors) where c is the content of the coefficients and
         factors is a list of (poly, exp) pairs.
 
-            >>> from flint import Ordering
             >>> Zm = fmpz_mod_mpoly
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(3, Ordering.lex, 11, 'x,y,z')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y', 'z'), 11, 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*y + 3*x + 3*y + 3", ctx)
             >>> (p1 * p2).factor_squarefree()
@@ -1000,8 +975,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         The argument can either be the variable as a string, or the index of the
         variable in the context.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -1025,8 +999,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Compute the inflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^N)``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, nametup=('x', 'y'))
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x + y + 1
             >>> f.inflate([2, 3])
@@ -1053,8 +1026,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Compute the deflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^(1/N))``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, nametup=('x', 'y'))
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> f.deflate([2, 3])
@@ -1078,8 +1050,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         Compute the deflation of ``self``, that is ``p(X^(1/N))`` for maximal
         N. Returns ``q, N`` such that ``self == q.inflate(N)``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, nametup=('x', 'y'))
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 * y**2 + x * y**2
             >>> q, N = f.deflation()
@@ -1110,8 +1081,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         = m * q(X^N)`` for maximal N. The returned monomial allows the undo-ing of the
         deflation.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, nametup=('x', 'y'))
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> fd, N, m = f.deflation_monom()
@@ -1141,8 +1111,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         exponents. It is the exponent vector of the monomial returned by
         ``deflation_monom``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mod_mpoly_ctx.get_context(2, Ordering.lex, 11, nametup=('x', 'y'))
+            >>> ctx = fmpz_mod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> N, I = f.deflation_index()

--- a/src/flint/types/fmpz_mod_mpoly.pyx
+++ b/src/flint/types/fmpz_mod_mpoly.pyx
@@ -89,7 +89,9 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
 
     _ctx_cache = _fmpz_mod_mpoly_ctx_cache
 
-    def __init__(self, names, ordering, modulus):
+    @classmethod
+    def _new_(cls, names, ordering, modulus):
+        cdef fmpz_mod_mpoly_ctx self = cls.__new__(cls)
         cdef fmpz m
         if not typecheck(modulus, fmpz):
             m = any_as_fmpz(modulus)
@@ -98,8 +100,9 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         else:
             m = modulus
 
-        super().__init__(names, m.is_prime())
+        super()._new_(self, names, m.is_prime())
         fmpz_mod_mpoly_ctx_init(self.val, len(names), ordering_py_to_c(ordering), m.val)
+        return self
 
     def _any_as_scalar(self, other):
         if isinstance(other, int):

--- a/src/flint/types/fmpz_mod_mpoly.pyx
+++ b/src/flint/types/fmpz_mod_mpoly.pyx
@@ -133,7 +133,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mpoly_context):
             raise ValueError("must provide either 'names' or 'nametup'")
         return key
 
-    def any_as_scalar(self, other):
+    def _any_as_scalar(self, other):
         if isinstance(other, int):
             return any_as_fmpz(other)
         elif typecheck(other, nmod):
@@ -157,8 +157,8 @@ cdef class fmpz_mod_mpoly_ctx(flint_mpoly_context):
         else:
             return NotImplemented
 
-    def scalar_as_mpoly(self, other: fmpz):
-        # non-fmpz scalars should first be converted via self.any_as_scalar
+    def _scalar_as_mpoly(self, other: fmpz):
+        # non-fmpz scalars should first be converted via self._any_as_scalar
         return self.constant(<fmpz>other)
 
     def nvars(self):
@@ -270,7 +270,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mpoly_context):
                 continue
 
             exp_vec = fmpz_vec(exps)
-            coeff_scalar = self.any_as_scalar(coeff)
+            coeff_scalar = self._any_as_scalar(coeff)
             if coeff_scalar is NotImplemented:
                 raise TypeError(f"cannot coerce {repr(coeff)} to nmod_mpoly coefficient")
 
@@ -425,7 +425,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
             raise ValueError("exponent vector provided does not match number of variables")
         exp_vec = fmpz_vec(x, double_indirect=True)
 
-        coeff = self.ctx.any_as_scalar(y)
+        coeff = self.ctx._any_as_scalar(y)
         if coeff is NotImplemented:
             raise TypeError("provided coefficient not coercible to fmpz")
         fmpz_mod_mpoly_set_coeff_fmpz_fmpz(self.val, (<fmpz>coeff).val, exp_vec.double_indirect, self.ctx.val)
@@ -566,7 +566,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
 
         if nargs != nvars:
             raise ValueError("number of generators does not match number of arguments")
-        args = [self.ctx.any_as_scalar(x) for x in args]
+        args = [self.ctx._any_as_scalar(x) for x in args]
         V = fmpz_vec(args, double_indirect=True)
         vres = fmpz.__new__(fmpz)
         fmpz_mod_mpoly_evaluate_all_fmpz(vres.val, self.val, V.double_indirect, self.ctx.val)
@@ -656,7 +656,7 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
             fmpz_mod_mpoly res
             slong i
 
-        args = tuple((self.ctx.variable_to_index(k), self.ctx.any_as_scalar(v)) for k, v in dict_args.items())
+        args = tuple((self.ctx.variable_to_index(k), self.ctx._any_as_scalar(v)) for k, v in dict_args.items())
         for (_, v), old in zip(args, dict_args.values()):
             if v is NotImplemented:
                 raise TypeError(f"cannot coerce {type(old)} to fmpz")

--- a/src/flint/types/fmpz_mod_mpoly.pyx
+++ b/src/flint/types/fmpz_mod_mpoly.pyx
@@ -89,7 +89,7 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
 
     _ctx_cache = _fmpz_mod_mpoly_ctx_cache
 
-    def __init__(self, slong nvars, ordering, names, modulus):
+    def __init__(self, names, ordering, modulus):
         cdef fmpz m
         if not typecheck(modulus, fmpz):
             m = any_as_fmpz(modulus)
@@ -98,8 +98,8 @@ cdef class fmpz_mod_mpoly_ctx(flint_mod_mpoly_context):
         else:
             m = modulus
 
-        super().__init__(nvars, names, m.is_prime())
-        fmpz_mod_mpoly_ctx_init(self.val, nvars, ordering_py_to_c(ordering), m.val)
+        super().__init__(names, m.is_prime())
+        fmpz_mod_mpoly_ctx_init(self.val, len(names), ordering_py_to_c(ordering), m.val)
 
     def _any_as_scalar(self, other):
         if isinstance(other, int):

--- a/src/flint/types/fmpz_mod_mpoly.pyx
+++ b/src/flint/types/fmpz_mod_mpoly.pyx
@@ -4,7 +4,6 @@ from flint.flint_base.flint_base cimport (
     ordering_py_to_c,
     ordering_c_to_py,
 )
-from flint.flint_base.flint_base import Ordering
 
 from flint.utils.typecheck cimport typecheck
 from flint.utils.flint_exceptions import DomainError, IncompatibleContextError

--- a/src/flint/types/fmpz_mpoly.pyx
+++ b/src/flint/types/fmpz_mpoly.pyx
@@ -106,7 +106,7 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
         fmpz_mpoly_ctx_init(self.val, nvars, ordering_py_to_c(ordering))
         super().__init__(nvars, names)
 
-    def any_as_scalar(self, other):
+    def _any_as_scalar(self, other):
         if isinstance(other, int):
             return any_as_fmpz(other)
         elif typecheck(other, fmpz):
@@ -116,8 +116,8 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
         else:
             return NotImplemented
 
-    def scalar_as_mpoly(self, other: fmpz):
-        # non-fmpz scalars should first be converted via self.any_as_scalar
+    def _scalar_as_mpoly(self, other: fmpz):
+        # non-fmpz scalars should first be converted via self._any_as_scalar
         return self.constant(<fmpz>other)
 
     def nvars(self):

--- a/src/flint/types/fmpz_mpoly.pyx
+++ b/src/flint/types/fmpz_mpoly.pyx
@@ -102,9 +102,9 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
 
     _ctx_cache = _fmpz_mpoly_ctx_cache
 
-    def __init__(self, slong nvars, ordering, names):
-        fmpz_mpoly_ctx_init(self.val, nvars, ordering_py_to_c(ordering))
-        super().__init__(nvars, names)
+    def __init__(self, names, ordering):
+        super().__init__(names)
+        fmpz_mpoly_ctx_init(self.val, len(names), ordering_py_to_c(ordering))
 
     def _any_as_scalar(self, other):
         if isinstance(other, int):

--- a/src/flint/types/fmpz_mpoly.pyx
+++ b/src/flint/types/fmpz_mpoly.pyx
@@ -124,8 +124,7 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
         """
         Return the number of variables in the context
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(4, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 4), 'lex')
             >>> ctx.nvars()
             4
         """
@@ -135,10 +134,9 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
         """
         Return the term order of the context object.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(4, Ordering.deglex, 'w')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('w', 4), 'deglex')
             >>> ctx.ordering()
-            <Ordering.deglex: 1>
+            <Ordering.deglex: 'deglex'>
         """
         return ordering_c_to_py(self.val.minfo.ord)
 
@@ -146,8 +144,7 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
         """
         Return the ``i`` th generator of the polynomial ring
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(3, Ordering.degrevlex, 'z')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('z', 3), 'degrevlex')
             >>> ctx.gen(1)
             z1
         """
@@ -177,8 +174,7 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
         The dictionary's keys are tuples of ints (or anything that implicitly converts
         to fmpz) representing exponents, and corresponding values of fmpz.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x,y')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> ctx.from_dict({(1,0):2, (1,1):3, (0,1):1})
             3*x*y + 2*x + y
         """
@@ -291,8 +287,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Always returns a value, missing keys will return ``0``.
         Negative exponents are made positive.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1]
             3
@@ -317,8 +312,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Will always set a value, missing keys will create a new term.
         Negative exponents are made positive.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1] = 20
             >>> p
@@ -502,8 +496,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the exponent vectors of each term as a tuple of fmpz.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.monoms()
             [(1, 1), (1, 0), (0, 1), (0, 0)]
@@ -524,8 +517,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the coefficients of each term as a fmpz
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.coeffs()
             [4, 2, 3, 1]
@@ -547,8 +539,7 @@ cdef class fmpz_mpoly(flint_mpoly):
     #     """
     #     Return the terms of this polynomial as a list of fmpz_mpolys.
 
-    #         >>> from flint import Ordering
-    #         >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+    #         >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
     #         >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
     #         >>> f.terms()
     #         [4*x0*x1, 2*x0, 3*x1, 1]
@@ -571,8 +562,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Partial evaluate this polynomial with select constants. Keys must be generator names or generator indices,
         all values must be fmpz.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.subs({"x1": 0})
             2*x0 + 1
@@ -601,9 +591,8 @@ cdef class fmpz_mpoly(flint_mpoly):
         Compose this polynomial with other fmpz_mpolys. All arguments must share the same context, it may different
         from this polynomials context.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(1, Ordering.lex, 'x')
-            >>> ctx1 = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'y')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x',), 'lex')
+            >>> ctx1 = fmpz_mpoly_ctx.get_context(('y', 2), 'lex')
             >>> f = ctx.from_dict({(2,): 1})
             >>> g = ctx1.from_dict({(1, 0): 1, (0, 1): 1})
             >>> f
@@ -651,8 +640,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the context object for this polynomials.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2})
             >>> ctx is p.context()
             True
@@ -663,8 +651,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the coefficient at index ``i``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.coefficient(1)
             2
@@ -681,8 +668,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the exponent vector at index ``i`` as a tuple.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.monomial(1)
             (0, 1)
@@ -700,8 +686,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return a dictionary of variable name to degree.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(4, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 4), 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.degrees()
             (1, 2, 3, 0)
@@ -717,8 +702,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the total degree.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(4, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 4), 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.total_degree()
             3
@@ -731,8 +715,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Leading coefficient in the monomial ordering.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx(2, Ordering.lex, ['x', 'y'])
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> p = 2*x*y + 3*x + 4*y**2 + 5
             >>> p
@@ -760,8 +743,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the gcd of self and other.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> g = ctx.from_dict({(0, 1): 2, (1, 0): 2})
             >>> (f * g).gcd(f)
@@ -780,8 +762,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the GCD of the coefficients of ``self``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = 3 * x0**2 * x1 + 6 * x0 * x1
             >>> f.content()
@@ -796,8 +777,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Return the GCD of the terms of ``self``. If ``self`` is zero, then the result will
         be zero, otherwise it will be a monomial with positive coefficient.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = 3 * x0**2 * x1 + 6 * x0 * x1
             >>> f.term_content()
@@ -811,8 +791,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the resultant of ``self`` and ``other`` with respect to variable ``var``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = x0**2 * x1 + x0 * x1
             >>> g = x0 + x1
@@ -838,8 +817,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the discriminant of ``self`` with respect to variable ``var``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = (x0 + x1)**2 + 1
             >>> f.discriminant('x1')
@@ -860,8 +838,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the content and primitive of ``self``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> x, y = ctx.gens()
             >>> f = 4*x + 2*x*y
             >>> f.primitive()
@@ -876,8 +853,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         If self is known to be a perfect square provide ``assume_perfect_square=True`` for a more efficient
         result. If self is not a square root the result is not guaranteed to be correct.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> (f * f).sqrt()
             4*x0*x1 + 1
@@ -896,9 +872,8 @@ cdef class fmpz_mpoly(flint_mpoly):
         (c, factors) where c is the content of the coefficients and
         factors is a list of (poly, exp) pairs.
 
-            >>> from flint import Ordering
             >>> Zm = fmpz_mpoly
-            >>> ctx = fmpz_mpoly_ctx.get_context(3, Ordering.lex, 'x,y,z')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y', 'z'), 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*z + 3*x + 3*z + 3", ctx)
             >>> (p1 * p2).factor()
@@ -936,9 +911,8 @@ cdef class fmpz_mpoly(flint_mpoly):
         (c, factors) where c is the content of the coefficients and
         factors is a list of (poly, exp) pairs.
 
-            >>> from flint import Ordering
             >>> Zm = fmpz_mpoly
-            >>> ctx = fmpz_mpoly_ctx.get_context(3, Ordering.lex, 'x,y,z')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y', 'z'), 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*y + 3*x + 3*y + 3", ctx)
             >>> (p1 * p2).factor_squarefree()
@@ -1003,8 +977,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         The argument can either be the variable as a string, or the index of the
         variable in the context.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -1030,8 +1003,7 @@ cdef class fmpz_mpoly(flint_mpoly):
 
         The argument can either be the variable as a string, or the index of the variable in the context.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, 'x')
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -1058,8 +1030,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Compute the S-polynomial of ``self`` and ``g``, scaled to an integer polynomial
         by computing the LCM of the leading coefficients.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> f = ctx.from_dict({(2, 0): 1, (0, 1): -1})
             >>> g = ctx.from_dict({(3, 0): 1, (1, 0): -1})
             >>> f.spoly(g)
@@ -1079,15 +1050,14 @@ cdef class fmpz_mpoly(flint_mpoly):
         Compute the the primitive part of the reduction (remainder of multivariate
         quasi-division with remainder) with respect to the polynomials ``vec``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = 2 * x**3 -x**2 * y + y**3 + 3 * y
             >>> g1 = x**2 + y**2 + 1
             >>> g2 = x * y - 2
             >>> vec = fmpz_mpoly_vec([g1, g2], ctx)
             >>> vec
-            fmpz_mpoly_vec([x^2 + y^2 + 1, x*y - 2], ctx=fmpz_mpoly_ctx(2, '<Ordering.lex: 0>', ('x', 'y')))
+            fmpz_mpoly_vec([x^2 + y^2 + 1, x*y - 2], ctx=fmpz_mpoly_ctx(2, '<Ordering.lex: 'lex'>', ('x', 'y')))
             >>> f.reduction_primitive_part(vec)
             x - y^3
         """
@@ -1104,8 +1074,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Compute the inflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^N)``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x + y + 1
             >>> f.inflate([2, 3])
@@ -1132,8 +1101,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Compute the deflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^(1/N))``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> f.deflate([2, 3])
@@ -1156,8 +1124,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Compute the deflation of ``self``, that is ``p(X^(1/N))`` for maximal N.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 * y**2 + x * y**2
             >>> q, N = f.deflation()
@@ -1188,8 +1155,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         = m * q(X^N)`` for maximal N. The returned monomial allows the undo-ing of the
         deflation.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> fd, N, m = f.deflation_monom()
@@ -1219,8 +1185,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         exponents. It is the exponent vector of the monomial returned by
         ``deflation_monom``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> N, I = f.deflation_index()
@@ -1345,8 +1310,7 @@ cdef class fmpz_mpoly_vec:
         Check if self is a Gröbner basis. If ``other`` is not None then check if self
         is a Gröbner basis for ``other``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 - y
             >>> g = x**3 - x
@@ -1376,8 +1340,7 @@ cdef class fmpz_mpoly_vec:
         """
         Check if self is auto-reduced (or inter-reduced).
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f2 = 3*x**2 - y
             >>> k = x*y - x
@@ -1399,8 +1362,7 @@ cdef class fmpz_mpoly_vec:
         Gröbner basis, compute the reduced reduced Gröbner basis of ``self``, throws an
         ``RuntimeError`` otherwise.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f2 = 3*x**2 - y
             >>> k2 = 3*x*y - 3*x
@@ -1412,7 +1374,7 @@ cdef class fmpz_mpoly_vec:
             >>> vec2.is_autoreduced()
             True
             >>> vec2
-            fmpz_mpoly_vec([3*x^2 - y, x*y - x, y^2 - y], ctx=fmpz_mpoly_ctx(2, '<Ordering.lex: 0>', ('x', 'y')))
+            fmpz_mpoly_vec([3*x^2 - y, x*y - x, y^2 - y], ctx=fmpz_mpoly_ctx(2, '<Ordering.lex: 'lex'>', ('x', 'y')))
         """
 
         cdef fmpz_mpoly_vec h = fmpz_mpoly_vec(0, self.ctx)
@@ -1447,8 +1409,7 @@ cdef class fmpz_mpoly_vec:
         implementation and does not compute a reduced basis. To construct a reduced
         basis use ``autoreduce``.
 
-            >>> from flint import Ordering
-            >>> ctx = fmpz_mpoly_ctx.get_context(2, Ordering.lex, nametup=('x', 'y'))
+            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 - y
             >>> g = x**3*y - x
@@ -1457,13 +1418,13 @@ cdef class fmpz_mpoly_vec:
             False
             >>> vec2 = vec.buchberger_naive()
             >>> vec2
-            fmpz_mpoly_vec([x^2 - y, x^3*y - x, x*y^2 - x, y^3 - y], ctx=fmpz_mpoly_ctx(2, '<Ordering.lex: 0>', ('x', 'y')))
+            fmpz_mpoly_vec([x^2 - y, x^3*y - x, x*y^2 - x, y^3 - y], ctx=fmpz_mpoly_ctx(2, '<Ordering.lex: 'lex'>', ('x', 'y')))
             >>> vec.buchberger_naive(limits=(2, 2, 512))
-            (fmpz_mpoly_vec([x^2 - y, x^3*y - x], ctx=fmpz_mpoly_ctx(2, '<Ordering.lex: 0>', ('x', 'y'))), False)
+            (fmpz_mpoly_vec([x^2 - y, x^3*y - x], ctx=fmpz_mpoly_ctx(2, '<Ordering.lex: 'lex'>', ('x', 'y'))), False)
             >>> vec2.is_autoreduced()
             False
             >>> vec2.autoreduction()
-            fmpz_mpoly_vec([x^2 - y, y^3 - y, x*y^2 - x], ctx=fmpz_mpoly_ctx(2, '<Ordering.lex: 0>', ('x', 'y')))
+            fmpz_mpoly_vec([x^2 - y, y^3 - y, x*y^2 - x], ctx=fmpz_mpoly_ctx(2, '<Ordering.lex: 'lex'>', ('x', 'y')))
         """
 
         cdef:

--- a/src/flint/types/fmpz_mpoly.pyx
+++ b/src/flint/types/fmpz_mpoly.pyx
@@ -101,9 +101,12 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
 
     _ctx_cache = _fmpz_mpoly_ctx_cache
 
-    def __init__(self, names, ordering):
-        super().__init__(names)
+    @classmethod
+    def _new_(cls, names, ordering):
+        cdef fmpz_mpoly_ctx self = cls.__new__(cls)
+        super()._new_(self, names)
         fmpz_mpoly_ctx_init(self.val, len(names), ordering_py_to_c(ordering))
+        return self
 
     def _any_as_scalar(self, other):
         if isinstance(other, int):

--- a/src/flint/types/fmpz_mpoly.pyx
+++ b/src/flint/types/fmpz_mpoly.pyx
@@ -93,9 +93,8 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
     """
     A class for storing the polynomial context
 
-    :param nvars: The number of variables in the ring
-    :param ordering:  The term order for the ring
     :param names:  A tuple containing the names of the variables of the ring.
+    :param ordering:  The term order for the ring.
 
     Do not construct one of these directly, use ``fmpz_mpoly_ctx.get``.
     """

--- a/src/flint/types/fmpz_mpoly.pyx
+++ b/src/flint/types/fmpz_mpoly.pyx
@@ -97,7 +97,7 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
     :param ordering:  The term order for the ring
     :param names:  A tuple containing the names of the variables of the ring.
 
-    Do not construct one of these directly, use ``fmpz_mpoly_ctx.get_context``.
+    Do not construct one of these directly, use ``fmpz_mpoly_ctx.get``.
     """
 
     _ctx_cache = _fmpz_mpoly_ctx_cache
@@ -124,7 +124,7 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
         """
         Return the number of variables in the context
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 4), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 4), 'lex')
             >>> ctx.nvars()
             4
         """
@@ -134,7 +134,7 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
         """
         Return the term order of the context object.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('w', 4), 'deglex')
+            >>> ctx = fmpz_mpoly_ctx.get(('w', 4), 'deglex')
             >>> ctx.ordering()
             <Ordering.deglex: 'deglex'>
         """
@@ -144,7 +144,7 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
         """
         Return the ``i`` th generator of the polynomial ring
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('z', 3), 'degrevlex')
+            >>> ctx = fmpz_mpoly_ctx.get(('z', 3), 'degrevlex')
             >>> ctx.gen(1)
             z1
         """
@@ -174,7 +174,7 @@ cdef class fmpz_mpoly_ctx(flint_mpoly_context):
         The dictionary's keys are tuples of ints (or anything that implicitly converts
         to fmpz) representing exponents, and corresponding values of fmpz.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> ctx.from_dict({(1,0):2, (1,1):3, (0,1):1})
             3*x*y + 2*x + y
         """
@@ -287,7 +287,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Always returns a value, missing keys will return ``0``.
         Negative exponents are made positive.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1]
             3
@@ -312,7 +312,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Will always set a value, missing keys will create a new term.
         Negative exponents are made positive.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1] = 20
             >>> p
@@ -496,7 +496,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the exponent vectors of each term as a tuple of fmpz.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.monoms()
             [(1, 1), (1, 0), (0, 1), (0, 0)]
@@ -517,7 +517,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the coefficients of each term as a fmpz
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.coeffs()
             [4, 2, 3, 1]
@@ -539,7 +539,7 @@ cdef class fmpz_mpoly(flint_mpoly):
     #     """
     #     Return the terms of this polynomial as a list of fmpz_mpolys.
 
-    #         >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+    #         >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
     #         >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
     #         >>> f.terms()
     #         [4*x0*x1, 2*x0, 3*x1, 1]
@@ -562,7 +562,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Partial evaluate this polynomial with select constants. Keys must be generator names or generator indices,
         all values must be fmpz.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.subs({"x1": 0})
             2*x0 + 1
@@ -591,8 +591,8 @@ cdef class fmpz_mpoly(flint_mpoly):
         Compose this polynomial with other fmpz_mpolys. All arguments must share the same context, it may different
         from this polynomials context.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x',), 'lex')
-            >>> ctx1 = fmpz_mpoly_ctx.get_context(('y', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x',), 'lex')
+            >>> ctx1 = fmpz_mpoly_ctx.get(('y', 2), 'lex')
             >>> f = ctx.from_dict({(2,): 1})
             >>> g = ctx1.from_dict({(1, 0): 1, (0, 1): 1})
             >>> f
@@ -640,7 +640,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the context object for this polynomials.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2})
             >>> ctx is p.context()
             True
@@ -651,7 +651,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the coefficient at index ``i``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.coefficient(1)
             2
@@ -668,7 +668,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the exponent vector at index ``i`` as a tuple.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.monomial(1)
             (0, 1)
@@ -686,7 +686,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return a dictionary of variable name to degree.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 4), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 4), 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.degrees()
             (1, 2, 3, 0)
@@ -702,7 +702,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the total degree.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 4), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 4), 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.total_degree()
             3
@@ -715,7 +715,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Leading coefficient in the monomial ordering.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> p = 2*x*y + 3*x + 4*y**2 + 5
             >>> p
@@ -743,7 +743,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the gcd of self and other.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> g = ctx.from_dict({(0, 1): 2, (1, 0): 2})
             >>> (f * g).gcd(f)
@@ -762,7 +762,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the GCD of the coefficients of ``self``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = 3 * x0**2 * x1 + 6 * x0 * x1
             >>> f.content()
@@ -777,7 +777,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Return the GCD of the terms of ``self``. If ``self`` is zero, then the result will
         be zero, otherwise it will be a monomial with positive coefficient.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = 3 * x0**2 * x1 + 6 * x0 * x1
             >>> f.term_content()
@@ -791,7 +791,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the resultant of ``self`` and ``other`` with respect to variable ``var``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = x0**2 * x1 + x0 * x1
             >>> g = x0 + x1
@@ -817,7 +817,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the discriminant of ``self`` with respect to variable ``var``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = (x0 + x1)**2 + 1
             >>> f.discriminant('x1')
@@ -838,7 +838,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Return the content and primitive of ``self``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> x, y = ctx.gens()
             >>> f = 4*x + 2*x*y
             >>> f.primitive()
@@ -853,7 +853,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         If self is known to be a perfect square provide ``assume_perfect_square=True`` for a more efficient
         result. If self is not a square root the result is not guaranteed to be correct.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> (f * f).sqrt()
             4*x0*x1 + 1
@@ -873,7 +873,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         factors is a list of (poly, exp) pairs.
 
             >>> Zm = fmpz_mpoly
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y', 'z'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y', 'z'), 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*z + 3*x + 3*z + 3", ctx)
             >>> (p1 * p2).factor()
@@ -912,7 +912,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         factors is a list of (poly, exp) pairs.
 
             >>> Zm = fmpz_mpoly
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y', 'z'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y', 'z'), 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*y + 3*x + 3*y + 3", ctx)
             >>> (p1 * p2).factor_squarefree()
@@ -977,7 +977,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         The argument can either be the variable as a string, or the index of the
         variable in the context.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -1003,7 +1003,7 @@ cdef class fmpz_mpoly(flint_mpoly):
 
         The argument can either be the variable as a string, or the index of the variable in the context.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 2), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 2), 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -1030,7 +1030,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Compute the S-polynomial of ``self`` and ``g``, scaled to an integer polynomial
         by computing the LCM of the leading coefficients.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> f = ctx.from_dict({(2, 0): 1, (0, 1): -1})
             >>> g = ctx.from_dict({(3, 0): 1, (1, 0): -1})
             >>> f.spoly(g)
@@ -1050,7 +1050,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Compute the the primitive part of the reduction (remainder of multivariate
         quasi-division with remainder) with respect to the polynomials ``vec``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = 2 * x**3 -x**2 * y + y**3 + 3 * y
             >>> g1 = x**2 + y**2 + 1
@@ -1074,7 +1074,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Compute the inflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^N)``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x + y + 1
             >>> f.inflate([2, 3])
@@ -1101,7 +1101,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         Compute the deflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^(1/N))``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> f.deflate([2, 3])
@@ -1124,7 +1124,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         """
         Compute the deflation of ``self``, that is ``p(X^(1/N))`` for maximal N.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 * y**2 + x * y**2
             >>> q, N = f.deflation()
@@ -1155,7 +1155,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         = m * q(X^N)`` for maximal N. The returned monomial allows the undo-ing of the
         deflation.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> fd, N, m = f.deflation_monom()
@@ -1185,7 +1185,7 @@ cdef class fmpz_mpoly(flint_mpoly):
         exponents. It is the exponent vector of the monomial returned by
         ``deflation_monom``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> N, I = f.deflation_index()
@@ -1310,7 +1310,7 @@ cdef class fmpz_mpoly_vec:
         Check if self is a Gröbner basis. If ``other`` is not None then check if self
         is a Gröbner basis for ``other``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 - y
             >>> g = x**3 - x
@@ -1340,7 +1340,7 @@ cdef class fmpz_mpoly_vec:
         """
         Check if self is auto-reduced (or inter-reduced).
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f2 = 3*x**2 - y
             >>> k = x*y - x
@@ -1362,7 +1362,7 @@ cdef class fmpz_mpoly_vec:
         Gröbner basis, compute the reduced reduced Gröbner basis of ``self``, throws an
         ``RuntimeError`` otherwise.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f2 = 3*x**2 - y
             >>> k2 = 3*x*y - 3*x
@@ -1409,7 +1409,7 @@ cdef class fmpz_mpoly_vec:
         implementation and does not compute a reduced basis. To construct a reduced
         basis use ``autoreduce``.
 
-            >>> ctx = fmpz_mpoly_ctx.get_context(('x', 'y'), 'lex')
+            >>> ctx = fmpz_mpoly_ctx.get(('x', 'y'), 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 - y
             >>> g = x**3*y - x

--- a/src/flint/types/nmod_mpoly.pxd
+++ b/src/flint/types/nmod_mpoly.pxd
@@ -1,4 +1,4 @@
-from flint.flint_base.flint_base cimport flint_mpoly, flint_mpoly_context
+from flint.flint_base.flint_base cimport flint_mpoly, flint_mod_mpoly_context
 
 from flint.flintlib.functions.nmod_mpoly cimport (
     nmod_mpoly_ctx_t,
@@ -21,9 +21,8 @@ cdef inline nmod_mpoly create_nmod_mpoly(nmod_mpoly_ctx ctx):
     var._init = True
     return var
 
-cdef class nmod_mpoly_ctx(flint_mpoly_context):
+cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
     cdef nmod_mpoly_ctx_t val
-    cdef readonly object __prime_modulus
 
 cdef class nmod_mpoly(flint_mpoly):
     cdef nmod_mpoly_t val

--- a/src/flint/types/nmod_mpoly.pyx
+++ b/src/flint/types/nmod_mpoly.pyx
@@ -94,12 +94,16 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
 
     _ctx_cache = _nmod_mpoly_ctx_cache
 
-    def __init__(self, names, ordering, modulus: int):
+    @classmethod
+    def _new_(cls, names, ordering, modulus: int):
+        cdef nmod_mpoly_ctx self = cls.__new__(cls)
+
         if modulus <= 0:
             raise ValueError("modulus must be positive")
 
-        super().__init__(names, <bint>n_is_prime(modulus))
+        super()._new_(self, names, <bint>n_is_prime(modulus))
         nmod_mpoly_ctx_init(self.val, len(names), ordering_py_to_c(ordering), modulus)
+        return self
 
     def _any_as_scalar(self, other):
         if isinstance(other, int):

--- a/src/flint/types/nmod_mpoly.pyx
+++ b/src/flint/types/nmod_mpoly.pyx
@@ -124,8 +124,7 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the number of variables in the context
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(4, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
             >>> ctx.nvars()
             4
         """
@@ -135,10 +134,9 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the term order of the context object.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(4, Ordering.deglex, 11, 'w')
+            >>> ctx = nmod_mpoly_ctx.get_context(('w', 4), 11, 'deglex')
             >>> ctx.ordering()
-            <Ordering.deglex: 1>
+            <Ordering.deglex: 'deglex'>
         """
         return ordering_c_to_py(self.val.minfo.ord)
 
@@ -146,8 +144,7 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the modulus of the context object.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(4, Ordering.deglex, 2, 'w')
+            >>> ctx = nmod_mpoly_ctx.get_context(('w', 4), 2, 'deglex')
             >>> ctx.modulus()
             2
 
@@ -158,8 +155,7 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the ``i`` th generator of the polynomial ring
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(3, Ordering.degrevlex, 11, 'z')
+            >>> ctx = nmod_mpoly_ctx.get_context(('z', 3), 11, 'degrevlex')
             >>> ctx.gen(1)
             z1
         """
@@ -186,8 +182,7 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
         The dictionary's keys are tuples of ints (or anything that implicitly converts
         to fmpz) representing exponents, and corresponding values of fmpz.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x,y')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> ctx.from_dict({(1,0):2, (1,1):3, (0,1):1})
             3*x*y + 2*x + y
         """
@@ -308,8 +303,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Always returns a value, missing keys will return ``0``.
         Negative exponents are made positive.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1]
             3
@@ -332,8 +326,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Will always set a value, missing keys will create a new term.
         Negative exponents are made positive.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1] = 20
             >>> p
@@ -513,8 +506,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the exponent vectors of each term as a tuple of fmpz.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.monoms()
             [(1, 1), (1, 0), (0, 1), (0, 0)]
@@ -535,8 +527,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the coefficients of each term as a fmpz
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.coeffs()
             [4, 2, 3, 1]
@@ -548,8 +539,7 @@ cdef class nmod_mpoly(flint_mpoly):
     #     """
     #     Return the terms of this polynomial as a list of nmod_mpolys.
 
-    #         >>> from flint import Ordering
-    #         >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+    #         >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
     #         >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
     #         >>> f.terms()
     #         [4*x0*x1, 2*x0, 3*x1, 1]
@@ -572,8 +562,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Partial evaluate this polynomial with select constants. Keys must be generator names or generator indices,
         all values must be fmpz.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.subs({"x1": 0})
             2*x0 + 1
@@ -601,9 +590,8 @@ cdef class nmod_mpoly(flint_mpoly):
         Compose this polynomial with other nmod_mpolys. All arguments must share the same context, it may different
         from this polynomials context.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(1, Ordering.lex, 11, 'x')
-            >>> ctx1 = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'y')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x',), 11, 'lex')
+            >>> ctx1 = nmod_mpoly_ctx.get_context(('y', 2), 11, 'lex')
             >>> f = ctx.from_dict({(2,): 1})
             >>> g = ctx1.from_dict({(1, 0): 1, (0, 1): 1})
             >>> f
@@ -649,8 +637,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the context object for this polynomials.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2})
             >>> ctx is p.context()
             True
@@ -661,8 +648,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the coefficient at index ``i``.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.coefficient(1)
             2
@@ -676,8 +662,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the exponent vector at index ``i`` as a tuple.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.monomial(1)
             (0, 1)
@@ -695,8 +680,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return a dictionary of variable name to degree.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(4, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.degrees()
             (1, 2, 3, 0)
@@ -712,8 +696,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the total degree.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(4, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.total_degree()
             3
@@ -726,8 +709,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Leading coefficient in the monomial ordering.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx(2, Ordering.lex, ['x', 'y'], 11)
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, Ordering.lex)
             >>> x, y = ctx.gens()
             >>> p = 2*x*y + 3*x + 4*y**2 + 5
             >>> p
@@ -755,8 +737,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the gcd of self and other.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> g = ctx.from_dict({(0, 1): 2, (1, 0): 2})
             >>> (f * g).gcd(f)
@@ -778,8 +759,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Return the GCD of the terms of ``self``. If ``self`` is zero, then the result will
         be zero, otherwise it will be a monomial with positive coefficient.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = 3 * x0**2 * x1 + 6 * x0 * x1
             >>> f.term_content()
@@ -794,8 +774,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the resultant of ``self`` and ``other`` with respect to variable ``var``.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = x0**2 * x1 + x0 * x1
             >>> g = x0 + x1
@@ -821,8 +800,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the discriminant of ``self`` with respect to variable ``var``.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = (x0 + x1)**2 + 1
             >>> f.discriminant('x1')
@@ -843,8 +821,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the square root of self.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> (f * f).sqrt()
             4*x0*x1 + 1
@@ -866,9 +843,8 @@ cdef class nmod_mpoly(flint_mpoly):
         (c, factors) where c is the content of the coefficients and
         factors is a list of (poly, exp) pairs.
 
-            >>> from flint import Ordering
             >>> Zm = nmod_mpoly
-            >>> ctx = nmod_mpoly_ctx.get_context(3, Ordering.lex, 11, 'x,y,z')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y', 'z'), 11, 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*z + 3*x + 3*z + 3", ctx)
             >>> (p1 * p2).factor()
@@ -908,9 +884,8 @@ cdef class nmod_mpoly(flint_mpoly):
         (c, factors) where c is the content of the coefficients and
         factors is a list of (poly, exp) pairs.
 
-            >>> from flint import Ordering
             >>> Zm = nmod_mpoly
-            >>> ctx = nmod_mpoly_ctx.get_context(3, Ordering.lex, 11, 'x,y,z')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y', 'z'), 11, 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*y + 3*x + 3*y + 3", ctx)
             >>> (p1 * p2).factor_squarefree()
@@ -978,8 +953,7 @@ cdef class nmod_mpoly(flint_mpoly):
         The argument can either be the variable as a string, or the index of the
         variable in the context.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, 'x')
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -1003,8 +977,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Compute the inflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^N)``.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, nametup=('x', 'y'))
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x + y + 1
             >>> f.inflate([2, 3])
@@ -1031,8 +1004,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Compute the deflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^(1/N))``.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, nametup=('x', 'y'))
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> f.deflate([2, 3])
@@ -1055,8 +1027,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Compute the deflation of ``self``, that is ``p(X^(1/N))`` for maximal N.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, nametup=('x', 'y'))
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 * y**2 + x * y**2
             >>> q, N = f.deflation()
@@ -1087,8 +1058,7 @@ cdef class nmod_mpoly(flint_mpoly):
         = m * q(X^N)`` for maximal N. The returned monomial allows the undo-ing of the
         deflation.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, nametup=('x', 'y'))
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> fd, N, m = f.deflation_monom()
@@ -1118,8 +1088,7 @@ cdef class nmod_mpoly(flint_mpoly):
         exponents. It is the exponent vector of the monomial returned by
         ``deflation_monom``.
 
-            >>> from flint import Ordering
-            >>> ctx = nmod_mpoly_ctx.get_context(2, Ordering.lex, 11, nametup=('x', 'y'))
+            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> N, I = f.deflation_index()

--- a/src/flint/types/nmod_mpoly.pyx
+++ b/src/flint/types/nmod_mpoly.pyx
@@ -89,7 +89,7 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
     :param ordering:  The term order for the ring
     :param names:  A tuple containing the names of the variables of the ring.
 
-    Do not construct one of these directly, use ``nmod_mpoly_ctx.get_context``.
+    Do not construct one of these directly, use ``nmod_mpoly_ctx.get``.
     """
 
     _ctx_cache = _nmod_mpoly_ctx_cache
@@ -124,7 +124,7 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the number of variables in the context
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 4), 11, 'lex')
             >>> ctx.nvars()
             4
         """
@@ -134,7 +134,7 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the term order of the context object.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('w', 4), 11, 'deglex')
+            >>> ctx = nmod_mpoly_ctx.get(('w', 4), 11, 'deglex')
             >>> ctx.ordering()
             <Ordering.deglex: 'deglex'>
         """
@@ -144,7 +144,7 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the modulus of the context object.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('w', 4), 2, 'deglex')
+            >>> ctx = nmod_mpoly_ctx.get(('w', 4), 2, 'deglex')
             >>> ctx.modulus()
             2
 
@@ -155,7 +155,7 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
         """
         Return the ``i`` th generator of the polynomial ring
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('z', 3), 11, 'degrevlex')
+            >>> ctx = nmod_mpoly_ctx.get(('z', 3), 11, 'degrevlex')
             >>> ctx.gen(1)
             z1
         """
@@ -182,7 +182,7 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
         The dictionary's keys are tuples of ints (or anything that implicitly converts
         to fmpz) representing exponents, and corresponding values of fmpz.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> ctx.from_dict({(1,0):2, (1,1):3, (0,1):1})
             3*x*y + 2*x + y
         """
@@ -303,7 +303,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Always returns a value, missing keys will return ``0``.
         Negative exponents are made positive.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1]
             3
@@ -326,7 +326,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Will always set a value, missing keys will create a new term.
         Negative exponents are made positive.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p[1, 1] = 20
             >>> p
@@ -506,7 +506,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the exponent vectors of each term as a tuple of fmpz.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.monoms()
             [(1, 1), (1, 0), (0, 1), (0, 0)]
@@ -527,7 +527,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the coefficients of each term as a fmpz
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.coeffs()
             [4, 2, 3, 1]
@@ -539,7 +539,7 @@ cdef class nmod_mpoly(flint_mpoly):
     #     """
     #     Return the terms of this polynomial as a list of nmod_mpolys.
 
-    #         >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+    #         >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
     #         >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
     #         >>> f.terms()
     #         [4*x0*x1, 2*x0, 3*x1, 1]
@@ -562,7 +562,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Partial evaluate this polynomial with select constants. Keys must be generator names or generator indices,
         all values must be fmpz.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(0, 0): 1, (1, 0): 2, (0, 1): 3, (1, 1): 4})
             >>> f.subs({"x1": 0})
             2*x0 + 1
@@ -590,8 +590,8 @@ cdef class nmod_mpoly(flint_mpoly):
         Compose this polynomial with other nmod_mpolys. All arguments must share the same context, it may different
         from this polynomials context.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x',), 11, 'lex')
-            >>> ctx1 = nmod_mpoly_ctx.get_context(('y', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x',), 11, 'lex')
+            >>> ctx1 = nmod_mpoly_ctx.get(('y', 2), 11, 'lex')
             >>> f = ctx.from_dict({(2,): 1})
             >>> g = ctx1.from_dict({(1, 0): 1, (0, 1): 1})
             >>> f
@@ -637,7 +637,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the context object for this polynomials.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2})
             >>> ctx is p.context()
             True
@@ -648,7 +648,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the coefficient at index ``i``.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.coefficient(1)
             2
@@ -662,7 +662,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the exponent vector at index ``i`` as a tuple.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 1): 2, (1, 1): 3})
             >>> p.monomial(1)
             (0, 1)
@@ -680,7 +680,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return a dictionary of variable name to degree.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 4), 11, 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.degrees()
             (1, 2, 3, 0)
@@ -696,7 +696,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the total degree.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 4), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 4), 11, 'lex')
             >>> p = ctx.from_dict({(1, 0, 0, 0): 1, (0, 2, 0, 0): 2, (0, 0, 3, 0): 3})
             >>> p.total_degree()
             3
@@ -709,7 +709,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Leading coefficient in the monomial ordering.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, Ordering.lex)
+            >>> ctx = nmod_mpoly_ctx.get(('x', 'y'), 11, Ordering.lex)
             >>> x, y = ctx.gens()
             >>> p = 2*x*y + 3*x + 4*y**2 + 5
             >>> p
@@ -737,7 +737,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the gcd of self and other.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> g = ctx.from_dict({(0, 1): 2, (1, 0): 2})
             >>> (f * g).gcd(f)
@@ -759,7 +759,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Return the GCD of the terms of ``self``. If ``self`` is zero, then the result will
         be zero, otherwise it will be a monomial with positive coefficient.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = 3 * x0**2 * x1 + 6 * x0 * x1
             >>> f.term_content()
@@ -774,7 +774,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the resultant of ``self`` and ``other`` with respect to variable ``var``.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = x0**2 * x1 + x0 * x1
             >>> g = x0 + x1
@@ -800,7 +800,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the discriminant of ``self`` with respect to variable ``var``.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> x0, x1 = ctx.gens()
             >>> f = (x0 + x1)**2 + 1
             >>> f.discriminant('x1')
@@ -821,7 +821,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Return the square root of self.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> f = ctx.from_dict({(1, 1): 4, (0, 0): 1})
             >>> (f * f).sqrt()
             4*x0*x1 + 1
@@ -844,7 +844,7 @@ cdef class nmod_mpoly(flint_mpoly):
         factors is a list of (poly, exp) pairs.
 
             >>> Zm = nmod_mpoly
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y', 'z'), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 'y', 'z'), 11, 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*z + 3*x + 3*z + 3", ctx)
             >>> (p1 * p2).factor()
@@ -885,7 +885,7 @@ cdef class nmod_mpoly(flint_mpoly):
         factors is a list of (poly, exp) pairs.
 
             >>> Zm = nmod_mpoly
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y', 'z'), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 'y', 'z'), 11, 'lex')
             >>> p1 = Zm("2*x + 4", ctx)
             >>> p2 = Zm("3*x*y + 3*x + 3*y + 3", ctx)
             >>> (p1 * p2).factor_squarefree()
@@ -953,7 +953,7 @@ cdef class nmod_mpoly(flint_mpoly):
         The argument can either be the variable as a string, or the index of the
         variable in the context.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 2), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 2), 11, 'lex')
             >>> p = ctx.from_dict({(0, 3): 2, (2, 1): 3})
             >>> p
             3*x0^2*x1 + 2*x1^3
@@ -977,7 +977,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Compute the inflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^N)``.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x + y + 1
             >>> f.inflate([2, 3])
@@ -1004,7 +1004,7 @@ cdef class nmod_mpoly(flint_mpoly):
         Compute the deflation of ``self`` for a provided ``N``, that is return ``q``
         such that ``q(X) = p(X^(1/N))``.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> f.deflate([2, 3])
@@ -1027,7 +1027,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Compute the deflation of ``self``, that is ``p(X^(1/N))`` for maximal N.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**2 * y**2 + x * y**2
             >>> q, N = f.deflation()
@@ -1058,7 +1058,7 @@ cdef class nmod_mpoly(flint_mpoly):
         = m * q(X^N)`` for maximal N. The returned monomial allows the undo-ing of the
         deflation.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> fd, N, m = f.deflation_monom()
@@ -1088,7 +1088,7 @@ cdef class nmod_mpoly(flint_mpoly):
         exponents. It is the exponent vector of the monomial returned by
         ``deflation_monom``.
 
-            >>> ctx = nmod_mpoly_ctx.get_context(('x', 'y'), 11, 'lex')
+            >>> ctx = nmod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> f = x**3 * y + x * y**4 + x * y
             >>> N, I = f.deflation_index()

--- a/src/flint/types/nmod_mpoly.pyx
+++ b/src/flint/types/nmod_mpoly.pyx
@@ -85,9 +85,9 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
     """
     A class for storing the polynomial context
 
-    :param nvars: The number of variables in the ring
-    :param ordering:  The term order for the ring
     :param names:  A tuple containing the names of the variables of the ring.
+    :param ordering:  The term order for the ring.
+    :param modulus:  The modulus for the ring.
 
     Do not construct one of these directly, use ``nmod_mpoly_ctx.get``.
     """

--- a/src/flint/types/nmod_mpoly.pyx
+++ b/src/flint/types/nmod_mpoly.pyx
@@ -94,12 +94,12 @@ cdef class nmod_mpoly_ctx(flint_mod_mpoly_context):
 
     _ctx_cache = _nmod_mpoly_ctx_cache
 
-    def __init__(self, slong nvars, ordering, names, modulus: int):
+    def __init__(self, names, ordering, modulus: int):
         if modulus <= 0:
             raise ValueError("modulus must be positive")
 
-        super().__init__(nvars, names, <bint>n_is_prime(modulus))
-        nmod_mpoly_ctx_init(self.val, nvars, ordering_py_to_c(ordering), modulus)
+        super().__init__(names, <bint>n_is_prime(modulus))
+        nmod_mpoly_ctx_init(self.val, len(names), ordering_py_to_c(ordering), modulus)
 
     def _any_as_scalar(self, other):
         if isinstance(other, int):

--- a/src/flint/types/nmod_mpoly.pyx
+++ b/src/flint/types/nmod_mpoly.pyx
@@ -712,7 +712,7 @@ cdef class nmod_mpoly(flint_mpoly):
         """
         Leading coefficient in the monomial ordering.
 
-            >>> ctx = nmod_mpoly_ctx.get(('x', 'y'), 11, Ordering.lex)
+            >>> ctx = nmod_mpoly_ctx.get(('x', 'y'), 11, 'lex')
             >>> x, y = ctx.gens()
             >>> p = 2*x*y + 3*x + 4*y**2 + 5
             >>> p

--- a/src/flint/types/nmod_mpoly.pyx
+++ b/src/flint/types/nmod_mpoly.pyx
@@ -4,7 +4,6 @@ from flint.flint_base.flint_base cimport (
     ordering_py_to_c,
     ordering_c_to_py,
 )
-from flint.flint_base.flint_base import Ordering
 
 from flint.utils.typecheck cimport typecheck
 from flint.utils.flint_exceptions import DomainError, IncompatibleContextError


### PR DESCRIPTION
Relevant issue: https://github.com/flintlib/python-flint/issues/195

This PR:
- Renames `get_context` -> `get`.
- Disables the `__init__` method for mpolys. If you really need a new context use `_new_` on a concrete subclass. Otherwise use `get`.
- Removes the number of variables arg from the `get` method. Only the names iterable, ordering, and when appropriate modulus is required now.
- Improves the variable naming system, e.g.
  ```python
            >>> flint_mpoly_context.create_variable_names('x')
            ('x',)
            >>> flint_mpoly_context.create_variable_names(('x', 3))
            ('x0', 'x1', 'x2')
            >>> flint_mpoly_context.create_variable_names([('x', 3), 'y'])
            ('x0', 'x1', 'x2', 'y')
  ```
  This applies to the `get` method indirectly
- Allows ordering to be specified as a string. The ordering enum is now also a `enum.StrEnum` so it should work seamlessly.
- Hides the `any_as_scalar` and `scalar_as_mpoly` methods. These should never have been public facing and are inconsistent at the moment. 
  The `nmod_mpoly.any_as_scalar` method is the only method to actually use `self`, this is required to get the modulus to allow conversion from arbitrary ints that are larger than `ulong` can hold
  I've also removed the exceptions they raised, they never did anything anyway
- Adds an intermediate `flint_mod_mpoly_context` class to hold some shared methods for the mod mpoly types.