### PR TITLE
Fix build error in fmpz_mod_mpoly when using flint HEAD

### DIFF
--- a/src/flint/flintlib/functions/compat.pxd
+++ b/src/flint/flintlib/functions/compat.pxd
@@ -1,0 +1,17 @@
+from flint.flintlib.types.flint cimport slong
+from flint.flintlib.types.fmpz_mod cimport fmpz_mod_mpoly_ctx_t, fmpz_mod_mpoly_t
+
+
+cdef extern from *:
+    """
+    #if __FLINT_RELEASE < 30200 /* Flint < 3.2.0 */
+
+    #define compat_fmpz_mod_mpoly_compose_fmpz_mod_mpoly_gen(...) (void)0
+
+    #else
+
+    #define compat_fmpz_mod_mpoly_compose_fmpz_mod_mpoly_gen(...) fmpz_mod_mpoly_compose_fmpz_mod_mpoly_gen(__VA_ARGS__)
+
+    #endif
+    """
+    void compat_fmpz_mod_mpoly_compose_fmpz_mod_mpoly_gen(fmpz_mod_mpoly_t A, const fmpz_mod_mpoly_t B, const slong * c, const fmpz_mod_mpoly_ctx_t ctxB, const fmpz_mod_mpoly_ctx_t ctxAC)

--- a/src/flint/flintlib/types/flint.pxd
+++ b/src/flint/flintlib/types/flint.pxd
@@ -52,10 +52,6 @@ cdef extern from *:
     #define flint_rand_clear flint_randclear
 
     #endif
-
-    /* FIXME: add version guard when https://github.com/flintlib/flint/pull/2068 */
-    /* is resolved */
-    #define fmpz_mod_mpoly_compose_fmpz_mod_mpoly_gen(...) (void)0
     """
 
 cdef extern from "flint/flint.h":

--- a/src/flint/types/fmpz_mod_mpoly.pyx
+++ b/src/flint/types/fmpz_mod_mpoly.pyx
@@ -5,6 +5,8 @@ from flint.flint_base.flint_base cimport (
     ordering_c_to_py,
 )
 
+from flint.flint_base.flint_base import FLINT_RELEASE
+
 from flint.utils.typecheck cimport typecheck
 from flint.utils.flint_exceptions import DomainError, IncompatibleContextError
 
@@ -19,7 +21,6 @@ from flint.flintlib.functions.fmpz_mod_mpoly cimport (
     fmpz_mod_mpoly_add_fmpz,
     fmpz_mod_mpoly_clear,
     fmpz_mod_mpoly_compose_fmpz_mod_mpoly,
-    # fmpz_mod_mpoly_compose_fmpz_mod_mpoly_gen,
     fmpz_mod_mpoly_ctx_get_modulus,
     fmpz_mod_mpoly_ctx_init,
     fmpz_mod_mpoly_deflate,
@@ -69,8 +70,10 @@ from flint.flintlib.functions.fmpz_mod_mpoly_factor cimport (
     fmpz_mod_mpoly_factor_squarefree,
     fmpz_mod_mpoly_factor_t,
 )
+from flint.flintlib.functions.compat cimport compat_fmpz_mod_mpoly_compose_fmpz_mod_mpoly_gen
 
 from flint.types.fmpz_mpoly cimport fmpz_mpoly_ctx, fmpz_mpoly
+
 
 from cpython.object cimport Py_EQ, Py_NE
 cimport libc.stdlib
@@ -1093,26 +1096,27 @@ cdef class fmpz_mod_mpoly(flint_mpoly):
         return list(stride), list(shift)
 
     cdef _compose_gens_(self, ctx, slong *mapping):
-        # FIXME: Remove this when https://github.com/flintlib/flint/pull/2068 is
-        # resolved
-
-        # cdef fmpz_mod_mpoly res = create_fmpz_mod_mpoly(ctx)
-        # fmpz_mod_mpoly_compose_fmpz_mod_mpoly_gen(
-        #     res.val,
-        #     self.val,
-        #     mapping,
-        #     self.ctx.val,
-        #     (<fmpz_mod_mpoly_ctx>ctx).val
-        # )
+        # FIXME: Remove this when FLINT < 3.2 is dropped
+        cdef fmpz_mod_mpoly res
+        if FLINT_RELEASE >= 30200:
+            res = create_fmpz_mod_mpoly(ctx)
+            compat_fmpz_mod_mpoly_compose_fmpz_mod_mpoly_gen(
+                res.val,
+                self.val,
+                mapping,
+                self.ctx.val,
+                (<fmpz_mod_mpoly_ctx>ctx).val
+            )
+            return res
 
         cdef:
             fmpz_mpoly_ctx mpoly_ctx = fmpz_mpoly_ctx.from_context(self.context())
             fmpz_mpoly_ctx res_ctx = fmpz_mpoly_ctx.from_context(ctx)
 
             fmpz_mpoly poly = mpoly_ctx.from_dict(self.to_dict())
-            fmpz_mpoly res = poly._compose_gens_(res_ctx, mapping)
+            fmpz_mpoly res1 = poly._compose_gens_(res_ctx, mapping)
 
-        return ctx.from_dict(res.to_dict())
+        return ctx.from_dict(res1.to_dict())
 
 
 cdef class fmpz_mod_mpoly_vec:


### PR DESCRIPTION
Apologies for the delay on this, I've had this fix sitting around since mentioned but haven't been able to test against HEAD due to nix build issues I was determined to fix. 

I've added a `compat.pxd` for small compatibility fixes like this. I noticed that there was a `fmpz_mod_mat_compat.pxd` but I don't feel like this deserved it's own file.

This will break when using Flint 3.2 below (or at) https://github.com/flintlib/flint/commit/02d4e5dde173124f1fdfb90c158791d2a4fbd3cd.

Closes #232
