### PR TITLE
Fix setup link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ as follows:
 See the documentation for further notes on building and installing
 python-flint:
 
-* https://python-flint.readthedocs.io/en/latest/setup.html
+* https://python-flint.readthedocs.io/en/latest/build.html
+* https://python-flint.readthedocs.io/en/latest/install.html
 
 Examples
 -------------------------------------


### PR DESCRIPTION
It was removed in
https://github.com/flintlib/python-flint/commit/73fbb625390149136f72a797cccda08eb499e16f