### PR TITLE
fix: Use nmod_mat_set_entry rather than internals

### DIFF
--- a/src/flint/types/nmod_mat.pyx
+++ b/src/flint/types/nmod_mat.pyx
@@ -119,7 +119,7 @@ cdef class nmod_mat(flint_mat):
                     row = val[i]
                     for j from 0 <= j < n:
                         x = nmod(row[j], mod)
-                        self.val.rows[i][j] = (<nmod>x).val
+                        nmod_mat_set_entry(self.val, i, j, x.val)
             else:
                 raise TypeError("cannot create nmod_mat from input of type %s" % type(val))
         elif len(args) == 2:
@@ -134,7 +134,7 @@ cdef class nmod_mat(flint_mat):
             for i from 0 <= i < m:
                 for j from 0 <= j < n:
                     x = nmod(entries[i*n + j], mod)         # XXX: slow
-                    self.val.rows[i][j] = (<nmod>x).val
+                    nmod_mat_set_entry(self.val, i, j, x.val)
         else:
             raise TypeError("nmod_mat: expected 1-3 arguments plus modulus")
 


### PR DESCRIPTION
See https://github.com/flintlib/python-flint/pull/252#issuecomment-2616692597.

Fix needed for compatibility with Flint 3.2 after https://github.com/flintlib/flint/pull/2162