### PR TITLE
gr: Improve conversions

### DIFF
--- a/src/flint/types/_gr.pxd
+++ b/src/flint/types/_gr.pxd
@@ -86,6 +86,8 @@ from flint.flintlib.functions.gr_domains cimport (
 )
 from flint.flintlib.functions.gr cimport (
     gr_heap_init,
+    gr_set_d,
+    gr_set_other,
     gr_set_str,
     gr_get_str,
     gr_set,
@@ -212,6 +214,24 @@ cdef class gr_ctx(flint_ctx):
         py_val.pval = pval
         py_val.ctx = self
         py_val._init = True
+        return py_val
+
+    @cython.final
+    cdef inline gr from_d(self, double d):
+        cdef gr py_val
+        py_val = self.new_gr()
+        err = gr_set_d(py_val.pval, d, self.ctx_t)
+        if err != GR_SUCCESS:
+            raise self._error(err, "Incorrect conversion from a double")
+        return py_val
+
+    @cython.final
+    cdef inline gr from_other(self, gr x):
+        cdef gr py_val
+        py_val = self.new_gr()
+        err = gr_set_other(py_val.pval, x.pval, x.ctx.ctx_t, self.ctx_t)
+        if err != GR_SUCCESS:
+            raise self._error(err, "Incorrect conversion")
         return py_val
 
     @cython.final

--- a/src/flint/types/_gr.pyx
+++ b/src/flint/types/_gr.pyx
@@ -224,11 +224,23 @@ cdef class gr_ctx(flint_ctx):
     def __call__(self, arg) -> gr:
         """Create a new element of the domain.
 
-        >>> from flint.types._gr import gr_fmpz_ctx
-        >>> ctx = gr_fmpz_ctx
-        >>> ctx(2)
-        2
+            >>> from flint.types._gr import gr_fmpz_ctx
+            >>> ctx = gr_fmpz_ctx
+            >>> ctx(2)
+            2
+            >>> ctx(18446744073709551615)
+            18446744073709551615
         """
+        if isinstance(arg, gr):
+            return self.from_other(arg)
+        if type(arg) is int:
+            try:
+                return self.from_si(arg)
+            except OverflowError:
+                pass
+        if type(arg) is float:
+            return self.from_d(arg)
+        # TODO: fmpz & fmpq ?
         try:
             return self.from_str(str(arg))
         except AssertionError:


### PR DESCRIPTION
C.f. https://flintlib.org/doc/gr.html#assignment-and-conversions

We can use more appropriate functions for conversions than roundtripping through a string