### PR TITLE
Add Linux aarch64 wheels

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-13, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -83,10 +83,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-13, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-13, macos-14]
         # This list to be kept in sync with cibuildwheel config
         # and python-requires in pyproject.toml.
-        python-version: ['3.10', '3.11', '3.12', '3.13-dev', 'pypy3.10']
+        python-version: ['3.11', '3.12', '3.13', 'pypy3.10']
 
     steps:
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "python-flint"
 description = "Bindings for FLINT"
 version = "0.7.0a5"
 # This needs to be in sync with README, cibuildwheel and CI config.
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 authors = [
     {name = "Fredrik Johansson", email = "fredrik.johansson@gmail.com"},
 ]
@@ -81,7 +81,7 @@ package = "flint"
 [tool.cibuildwheel]
 # requires-python needs to keep in sync with this and also the list of Python
 # versions the wheels are tested against in CI.
-build = "cp310-* cp311-* cp312-* cp313-* pp310-*"
+build = "cp311-* cp312-* cp313-* pp310-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux_*"
 
 # This is needed for free-threaded wheels:
@@ -89,6 +89,7 @@ skip = "*-win32 *-manylinux_i686 *-musllinux_*"
 # free-threaded-support = true
 
 manylinux-x86_64-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 test-command = "python -c \"import flint; print(str(flint.fmpz(2)))\""
 


### PR DESCRIPTION
GitHub Actions now provides Linux aarch64 runners:

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Fixes gh-105