### PR TITLE
fmpz_mat: add fraction-free LU decomposition

### DIFF
--- a/src/flint/flintlib/types/flint.pxd
+++ b/src/flint/flintlib/types/flint.pxd
@@ -55,6 +55,9 @@ cdef extern from *:
     """
 
 cdef extern from "flint/flint.h":
+    # These defines are needed to work around a Cython bug.
+    # Otherwise sizeof(ulong) will give the wrong size on 64 bit Windows.
+    # https://github.com/cython/cython/issues/6339
     """
     #define SIZEOF_ULONG sizeof(ulong)
     #define SIZEOF_SLONG sizeof(slong)

--- a/src/flint/types/fmpz_mat.pyx
+++ b/src/flint/types/fmpz_mat.pyx
@@ -9,6 +9,8 @@ from flint.types.fmpq cimport any_as_fmpq
 cimport cython
 cimport libc.stdlib
 
+from flint.flintlib.types.flint cimport SIZEOF_SLONG
+
 from flint.flintlib.functions.fmpz cimport (
     fmpz_set,
     fmpz_init,
@@ -660,7 +662,7 @@ cdef class fmpz_mat(flint_mat):
         cdef fmpz_mat LU
         r = fmpz_mat_nrows(self.val)
         c = fmpz_mat_ncols(self.val)
-        perm = <slong*>libc.stdlib.malloc(r * sizeof(slong))
+        perm = <slong*>libc.stdlib.malloc(r * SIZEOF_SLONG)
         if perm is NULL:
             raise MemoryError("malloc failed")
         try:


### PR DESCRIPTION
Add various matrix properties like `is_square` following the `gr_mat` convention.

Adds fraction-free LU decomposition (FFLU) to compute matrices, P, L, U and D such that `P*A = L*D^-1*U`.

All these methods could come from `gr_mat` but it is useful to implement them now along with tests in preparation for later.