### PR TITLE
maint: bump cibuildwheel, mpfr and flint

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ matrix.os == 'windows-2019' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@d04cacbc9866d432033b1d09142936e6a0e2121a # v2.23.2
+        uses: pypa/cibuildwheel@90a0ddeff0f23eebc21630e65d66d0f4955e9b94 # v3.0.0b1
         env:
           # override setting in pyproject.toml to use msys2 instead of msys64 bash
           CIBW_BEFORE_ALL_WINDOWS: msys2 -c bin/cibw_before_all_windows.sh

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -170,7 +170,7 @@ jobs:
       fail-fast: false
       matrix:
         # Supported Flint versions:
-        flint-tag: ['v3.0.1', 'v3.1.3-p1', 'v3.2.0-rc1']
+        flint-tag: ['v3.0.1', 'v3.1.3-p1', 'v3.2.2']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -84,8 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-13, macos-14]
-        # This list to be kept in sync with cibuildwheel config
-        # and python-requires in pyproject.toml.
+        # This list to be kept in sync with python-requires in pyproject.toml.
         python-version: ['3.11', '3.12', '3.13', '3.13t', 'pypy3.11']
 
     steps:

--- a/bin/build_variables.sh
+++ b/bin/build_variables.sh
@@ -20,5 +20,5 @@ MPIRVER=3.0.0 # MPIR build no longer works (not clear where to download from)
 
 # These are the actual dependencies used (at least by default):
 GMPVER=6.3.0
-MPFRVER=4.1.0
-FLINTVER='3.2.0'
+MPFRVER=4.2.2
+FLINTVER='3.2.2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,11 +82,10 @@ package = "flint"
 [tool.cibuildwheel]
 # requires-python needs to keep in sync with this and also the list of Python
 # versions the wheels are tested against in CI.
-build = "cp311-* cp312-* cp313-* cp313t-* pp311-*"
-skip = "*-win32 *-manylinux_i686 *-musllinux_*"
+skip = "*-win32 *-manylinux_i686 *-manylinux_armv7l *-musllinux_*"
 
 # Enable building for free-threaded CPython builds
-enable = ["cpython-freethreading"]
+enable = ["cpython-freethreading", "pypy"]
 
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux_2_28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "python-flint"
 description = "Bindings for FLINT"
 version = "0.7.1"
-# This needs to be in sync with README, cibuildwheel and CI config.
+# This needs to be in sync with README, and CI config.
 requires-python = ">= 3.11"
 authors = [
     {name = "Fredrik Johansson", email = "fredrik.johansson@gmail.com"},
@@ -80,8 +80,6 @@ package = "flint"
 ]
 
 [tool.cibuildwheel]
-# requires-python needs to keep in sync with this and also the list of Python
-# versions the wheels are tested against in CI.
 skip = "*-win32 *-manylinux_i686 *-manylinux_armv7l *-musllinux_*"
 
 # Enable building for free-threaded CPython builds


### PR DESCRIPTION
Bump version constraints for Cython 3.1.