### PR TITLE
Bump from windows-2019 to windows-2022 in CI

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-13, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,17 +29,17 @@ jobs:
           # problematic in some situations. Maybe there is a better way to do
           # this.
           path-type: inherit
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
 
         # Install pkgconfig on Windows from choco rather than from msys and
         # avoid using the Strawberry one.
       - run: choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
 
         # We have to set this here rather than in the cibuildwheel config
         # This is probably something to do with \ vs / in paths...
       - run: echo "PKG_CONFIG_PATH=${{ github.workspace }}/.local/lib/pkgconfig" >> $env:GITHUB_ENV
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
 
       - name: Build wheels
         uses: pypa/cibuildwheel@90a0ddeff0f23eebc21630e65d66d0f4955e9b94 # v3.0.0b1
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-13, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-13, macos-14]
         # This list to be kept in sync with python-requires in pyproject.toml.
         python-version: ['3.11', '3.12', '3.13', '3.13t', 'pypy3.11']
 

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-13, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,17 +29,17 @@ jobs:
           # problematic in some situations. Maybe there is a better way to do
           # this.
           path-type: inherit
-        if: ${{ matrix.os == 'windows-2022' }}
+        if: ${{ matrix.os == 'windows-2019' }}
 
         # Install pkgconfig on Windows from choco rather than from msys and
         # avoid using the Strawberry one.
       - run: choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
-        if: ${{ matrix.os == 'windows-2022' }}
+        if: ${{ matrix.os == 'windows-2019' }}
 
         # We have to set this here rather than in the cibuildwheel config
         # This is probably something to do with \ vs / in paths...
       - run: echo "PKG_CONFIG_PATH=${{ github.workspace }}/.local/lib/pkgconfig" >> $env:GITHUB_ENV
-        if: ${{ matrix.os == 'windows-2022' }}
+        if: ${{ matrix.os == 'windows-2019' }}
 
       - name: Build wheels
         uses: pypa/cibuildwheel@90a0ddeff0f23eebc21630e65d66d0f4955e9b94 # v3.0.0b1

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-13, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,17 +29,17 @@ jobs:
           # problematic in some situations. Maybe there is a better way to do
           # this.
           path-type: inherit
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
 
         # Install pkgconfig on Windows from choco rather than from msys and
         # avoid using the Strawberry one.
       - run: choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
 
         # We have to set this here rather than in the cibuildwheel config
         # This is probably something to do with \ vs / in paths...
       - run: echo "PKG_CONFIG_PATH=${{ github.workspace }}/.local/lib/pkgconfig" >> $env:GITHUB_ENV
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
 
       - name: Build wheels
         uses: pypa/cibuildwheel@90a0ddeff0f23eebc21630e65d66d0f4955e9b94 # v3.0.0b1
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-13, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-13, macos-14]
         # This list to be kept in sync with python-requires in pyproject.toml.
         python-version: ['3.11', '3.12', '3.13', '3.13t', 'pypy3.11']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ enable = ["cpython-freethreading", "pypy"]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux_2_28"
 manylinux-i686-image = "manylinux2014"
-test-command = "python -c \"import flint; print(str(flint.fmpz(2)))\""
 
 [tool.cibuildwheel.linux.environment]
 # LD_LIBRARY_PATH is needed by auditwheel


### PR DESCRIPTION
The windows-2019 image is no longer supported by GitHub Actions.

In gh-289 I found that the Windows build failed because of a new version of the setup-msys2 action. Looking into that I discovered that the GitHub actions windows-2019 runners will not be available by the end of the month (in a week!). Bumping to windows-2025 didn't work so we'll try windows-2022.

If this works then the msys2 issue still remains but we have another few years before needing to bump the Windows version.