### PR TITLE
CI: test all available OS in CI

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -83,7 +83,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-13, macos-14]
+        os: [
+          ubuntu-22.04,
+          ubuntu-24.04,
+          ubuntu-24.04-arm,
+          windows-2019,
+          windows-2022,
+          windows-2025,
+          macos-13,
+          macos-14,
+          macos-15,
+        ]
         # This list to be kept in sync with python-requires in pyproject.toml.
         python-version: ['3.11', '3.12', '3.13', '3.13t', 'pypy3.11']
 


### PR DESCRIPTION
Following up from gh-290.

It seems that the wheels built in CI on windows-2019 runners fail on windows-2022 runners. This PR just makes sure that the built wheels are tested on all versions of Windows, MacOS and Ubuntu available as standard GitHub Actions runners. I expect then that the windows-2022 and windows-2025 jobs here will fail.

Afterwards I'll test the effect of trying to build on a different Windows version.