### PR TITLE
Extend mul_low and pow_trunc methods to fmpz_poly, fmpq_poly, nmod_poly

### DIFF
--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -2964,6 +2964,11 @@ def test_polys(args: _PolyTestCase[typ.epoly_p[Tc], Tc]) -> None:
     assert raises(lambda: P([1, 1]) ** -1, DomainError)
     assert raises(lambda: P([1, 1]) ** None, TypeError) # type: ignore
 
+    # Truncated operations
+    assert P([1, 2, 3]).mul_low(P([4, 5, 6]), 3) == P([4, 13, 28])
+    assert raises(lambda: P([1, 2, 3]).mul_low(None, 3), TypeError) # type: ignore
+    assert raises(lambda: P([1, 2, 3]).mul_low(P([4, 5, 6]), None), TypeError) # type: ignore
+
     # XXX: Not sure what this should do in general:
     p = P([1, 1])
     mod = P([1, 1])

--- a/src/flint/types/fmpq_poly.pyx
+++ b/src/flint/types/fmpq_poly.pyx
@@ -502,6 +502,53 @@ cdef class fmpq_poly(flint_poly):
         fmpq_poly_pow(res.val, self.val, <ulong>exp)
         return res
 
+    def mul_low(self, other, slong n):
+        r"""
+        Returns the lowest ``n`` coefficients of the multiplication of ``self`` with ``other``
+
+        Equivalent to computing `f(x) \cdot g(x) \mod x^n`
+
+            >>> f = fmpq_poly([2,3,5,7,11])
+            >>> g = fmpq_poly([1,2,4,8,16])
+            >>> f.mul_low(g, 5)
+            101*x^4 + 45*x^3 + 19*x^2 + 7*x + 2
+            >>> f.mul_low(g, 3)
+            19*x^2 + 7*x + 2
+            >>> f.mul_low(g, 1)
+            2
+        """
+        # Only allow multiplication with other fmpq_poly
+        if not typecheck(other, fmpq_poly):
+            raise TypeError("other polynomial must be of type fmpq_poly")
+
+        cdef fmpq_poly res
+        res = fmpq_poly.__new__(fmpq_poly)
+        fmpq_poly_mullow(res.val, self.val, (<fmpq_poly>other).val, n)
+        return res
+
+    def pow_trunc(self, slong e, slong n):
+        r"""
+        Returns ``self`` raised to the power ``e`` modulo `x^n`:
+        :math:`f^e \mod x^n`/
+
+        Note: For exponents larger that 2^63 (which do not fit inside a slong) use the
+        method :meth:`~.pow_mod` with the explicit modulus `x^n`.
+
+            >>> f = fmpq_poly([1, 2, 3])
+            >>> x = fmpq_poly([0, 1])
+            >>> f.pow_trunc(2**20, 4)
+            1537230871828889600*x^3 + 2199024304128*x^2 + 2097152*x + 1
+            >>> f.pow_trunc(5**25, 3)
+            177635683940025046765804290771484375*x^2 + 596046447753906250*x + 1
+        """
+        if e < 0:
+            raise ValueError("Exponent must be non-negative")
+
+        cdef fmpq_poly res
+        res = fmpq_poly.__new__(fmpq_poly)
+        fmpq_poly_pow_trunc(res.val, self.val, e, n)
+        return res
+
     def gcd(self, other):
         """
         Returns the greatest common divisor of *self* and *other*.

--- a/src/flint/types/fmpz_mod_poly.pyx
+++ b/src/flint/types/fmpz_mod_poly.pyx
@@ -1673,7 +1673,7 @@ cdef class fmpz_mod_poly(flint_poly):
         Returns ``self`` raised to the power ``e`` modulo `x^n`:
         :math:`f^e \mod x^n`/
 
-        Note: For exponents larger that 2^31 (which do not fit inside a ulong) use the
+        Note: For exponents larger that 2^63 (which do not fit inside a slong) use the
         method :meth:`~.pow_mod` with the explicit modulus `x^n`.
 
             >>> R = fmpz_mod_poly_ctx(163)
@@ -1683,6 +1683,8 @@ cdef class fmpz_mod_poly(flint_poly):
             True
             >>> f.pow_trunc(2**20, 5)
             132*x^4 + 113*x^3 + 36*x^2 + 48*x + 6
+            >>> f.pow_trunc(5**25, 5)
+            147*x^4 + 98*x^3 + 95*x^2 + 33*x + 126
         """
         if e < 0:
             raise ValueError("Exponent must be non-negative")

--- a/src/flint/types/fmpz_poly.pyx
+++ b/src/flint/types/fmpz_poly.pyx
@@ -483,6 +483,53 @@ cdef class fmpz_poly(flint_poly):
         fmpz_poly_pow(res.val, self.val, <ulong>exp)
         return res
 
+    def mul_low(self, other, slong n):
+        r"""
+        Returns the lowest ``n`` coefficients of the multiplication of ``self`` with ``other``
+
+        Equivalent to computing `f(x) \cdot g(x) \mod x^n`
+
+            >>> f = fmpz_poly([2,3,5,7,11])
+            >>> g = fmpz_poly([1,2,4,8,16])
+            >>> f.mul_low(g, 5)
+            101*x^4 + 45*x^3 + 19*x^2 + 7*x + 2
+            >>> f.mul_low(g, 3)
+            19*x^2 + 7*x + 2
+            >>> f.mul_low(g, 1)
+            2
+        """
+        # Only allow multiplication with other fmpz_poly
+        if not typecheck(other, fmpz_poly):
+            raise TypeError("other polynomial must be of type fmpz_poly")
+
+        cdef fmpz_poly res
+        res = fmpz_poly.__new__(fmpz_poly)
+        fmpz_poly_mullow(res.val, self.val, (<fmpz_poly>other).val, n)
+        return res
+
+    def pow_trunc(self, slong e, slong n):
+        r"""
+        Returns ``self`` raised to the power ``e`` modulo `x^n`:
+        :math:`f^e \mod x^n`/
+
+        Note: For exponents larger that 2^63 (which do not fit inside a slong) use the
+        method :meth:`~.pow_mod` with the explicit modulus `x^n`.
+
+            >>> f = fmpz_poly([1, 2, 3])
+            >>> x = fmpz_poly([0, 1])
+            >>> f.pow_trunc(2**20, 4)
+            1537230871828889600*x^3 + 2199024304128*x^2 + 2097152*x + 1
+            >>> f.pow_trunc(5**25, 3)
+            177635683940025046765804290771484375*x^2 + 596046447753906250*x + 1
+        """
+        if e < 0:
+            raise ValueError("Exponent must be non-negative")
+
+        cdef fmpz_poly res
+        res = fmpz_poly.__new__(fmpz_poly)
+        fmpz_poly_pow_trunc(res.val, self.val, e, n)
+        return res
+
     def gcd(self, other):
         """
         Returns the greatest common divisor of self and other.

--- a/src/flint/types/fq_default_poly.pyx
+++ b/src/flint/types/fq_default_poly.pyx
@@ -1195,7 +1195,7 @@ cdef class fq_default_poly(flint_poly):
         Returns ``self`` raised to the power ``e`` modulo `x^n`:
         :math:`f^e \mod x^n`/
 
-        Note: For exponents larger that 2^31 (which do not fit inside a ulong) use the
+        Note: For exponents larger that 2^63 (which do not fit inside a slong) use the
         method :meth:`~.pow_mod` with the explicit modulus `x^n`.
 
             >>> R = fq_default_poly_ctx(163)
@@ -1205,6 +1205,8 @@ cdef class fq_default_poly(flint_poly):
             True
             >>> f.pow_trunc(2**20, 5)
             132*x^4 + 113*x^3 + 36*x^2 + 48*x + 6
+            >>> f.pow_trunc(5**25, 5)
+            147*x^4 + 98*x^3 + 95*x^2 + 33*x + 126
         """
         if e < 0:
             raise ValueError("Exponent must be non-negative")


### PR DESCRIPTION
These methods already exist on fmpz_mod_poly and fq_default_poly.

Additionally, the existing docstrings and doctests are updated to assume the upper bound of slong is 2^63. Let me know if this is not fine (current all configured Github runners are 64-bit platforms). I am unsure whether 64-bit specific tests are fine.