### PR TITLE
CI: Use macos-15-intel runner for x86-64 Mac build

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2022, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2022, macos-15-intel, macos-14]
 
     steps:
       - uses: actions/checkout@v5
@@ -78,7 +78,7 @@ jobs:
           ubuntu-24.04-arm,
           windows-2022,
           windows-2025,
-          macos-13,
+          macos-15-intel,
           macos-14,
           macos-15,
           ]


### PR DESCRIPTION
Seems to be a new runner for intel macs that is supported for another 2 years.