### PR TITLE
.github/workflows/buildwheel.yml: Use macos-15-intel runners

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2022, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2022, macos-15-intel, macos-14]
 
     steps:
       - uses: actions/checkout@v5
@@ -78,7 +78,7 @@ jobs:
           ubuntu-24.04-arm,
           windows-2022,
           windows-2025,
-          macos-13,
+          macos-15-intel,
           macos-14,
           macos-15,
           ]


### PR DESCRIPTION
The `macos-13` runners are deprecated and will disappear by the end of the year.
`macos-15-intel` runners can be used instead for building and testing on x86_64, until at least August 2027.