### PR TITLE
Add hash function and re-enable hash tests

### DIFF
--- a/src/flint/test/test_arb.py
+++ b/src/flint/test/test_arb.py
@@ -126,20 +126,19 @@ def test_hash():
         (arb(10), arb(10), True),
         (arb(10), arb(11), False),
         (arb(10.0), arb(10), True),
-        (
-            arb(mid=10, rad=2),
-            arb(mid=10, rad=2),
-            True,
-        ),
-        (
-            arb(mid=10, rad=2),
-            arb(mid=10, rad=3),
-            False,
-        ),
-        (arb_pi(100), arb_pi(100), True),
-        (arb_pi(100), arb_pi(1000), False),
     ]:
         assert (hash(x) == hash(y)) == expected
+
+    for x in [
+        arb(mid=10, rad=2),
+        arb_pi(100),
+    ]:
+        try:
+            hash(x)
+        except ValueError:
+            pass
+        else:
+            assert False, f"Expected {x} to raise an error if hashed, but succeeded."
 
 
 

--- a/src/flint/types/arb.pyx
+++ b/src/flint/types/arb.pyx
@@ -529,7 +529,9 @@ cdef class arb(flint_scalar):
 
     def __hash__(self):
         """Hash."""
-        return hash((self.mid().man_exp(), self.rad().man_exp()))
+        if self.is_exact():
+            return hash((self.mid().man_exp(), self.rad().man_exp()))
+        raise ValueError(f"Cannot hash non-exact arb: {self}. See pull/341 for details.")
 
     def __contains__(self, other):
         other = any_as_arb(other)


### PR DESCRIPTION
This has function does not match the behavior of `__eq__` - non exact arbs with the same midpoint and radius will hash to the same value even though they're not mathematically equal. I considered having non-exact arbs return random hash values, but that feels wrong (though I do note that the python documentation doesn't explicitly forbid it), and it wouldn't even always work (hash collisions do exist). I also considered hashing the object id for non-exact arbs, but non-exact arbs aren't equal to themselves, so that doesn't quite work correctly either. Overall, this seemed like the simplest solution, even if it does have the possibility to create poor performance if you try to use non-exact arbs in a hashing data structure.