### PR TITLE
fix(fq_default): store variable name as str

### DIFF
--- a/src/flint/test/test_all.py
+++ b/src/flint/test/test_all.py
@@ -4720,9 +4720,6 @@ def test_fq_default():
     assert raises(lambda: flint.fq_default_ctx(5, fq_type=-1), ValueError)
     assert raises(lambda: flint.fq_default_ctx("ABC"), TypeError) # type: ignore
 
-    # var must be one character
-    assert raises(lambda: flint.fq_default_ctx(5, var="XXX"), ValueError)
-
     # p must be set if modulus has no characteristic / modulus
     assert raises(lambda: flint.fq_default_ctx(modulus=[0,1,0]), ValueError)
 
@@ -4777,7 +4774,7 @@ def test_fq_default():
     assert str(gf_5) == "Context for fq_default in GF(5)"
     assert str(gf_5_2) == "Context for fq_default in GF(5^2)[z]/(z^2 + 4*z + 2)"
 
-    assert repr(gf_5) == "fq_default_ctx(5, var='z' type='NMOD')"
+    assert repr(gf_5) == "fq_default_ctx(5, var='z', type='NMOD')"
     assert repr(gf_5_2) == "fq_default_ctx(5, 2, 'z', x^2 + 4*x + 2, 'FQ_ZECH')"
 
     # coercision

--- a/src/flint/types/fq_default.pxd
+++ b/src/flint/types/fq_default.pxd
@@ -24,7 +24,7 @@ cpdef enum fq_default_type:
 
 cdef class fq_default_ctx:
     cdef fq_default_ctx_t val
-    cdef readonly char *var
+    cdef str var
     cdef bint _initialized
 
     cdef new_ctype_fq_default(self)


### PR DESCRIPTION
Fixes gh-325

Previously, the variable name was stored as a char* pointing to the buffer for a bytes object that might be deallocated.