### PR TITLE
Use PEP 757 API for fmpz <-> int conversions

### DIFF
--- a/src/flint/flintlib/functions/fmpz.pxd
+++ b/src/flint/flintlib/functions/fmpz.pxd
@@ -1,4 +1,4 @@
-from flint.flintlib.types.flint cimport flint_bitcnt_t, flint_rand_t, fmpz_struct, fmpz_t, nmod_t, nn_ptr, nn_srcptr, slong, ulong
+from flint.flintlib.types.flint cimport flint_bitcnt_t, flint_rand_t, fmpz_struct, fmpz_t, nmod_t, nn_ptr, nn_srcptr, slong, ulong, mpz_ptr, mpz_t
 from flint.flintlib.types.fmpz cimport fmpz_factor_t, fmpz_preinvn_t
 
 # unknown type FILE
@@ -17,6 +17,11 @@ from flint.flintlib.types.fmpz cimport fmpz_factor_t, fmpz_preinvn_t
 # .. macro:: COEFF_IS_MPZ(f)
 # .. macro:: MPZ_MIN_ALLOC
 
+cdef extern from "gmp.h":
+    void mpz_import(mpz_t val, size_t count, int order, size_t size, int endian, size_t nails, const void * op)
+    void * mpz_export (void *rop, size_t *countp, int order, size_t size, int endian, size_t nails, const mpz_t op)
+
+
 cdef extern from "flint/fmpz.h":
     # fmpz_struct PTR_TO_COEFF(mpz_ptr ptr)
     # mpz_ptr COEFF_TO_PTR(fmpz_struct f)
@@ -25,7 +30,7 @@ cdef extern from "flint/fmpz.h":
     void _fmpz_cleanup_mpz_content()
     void _fmpz_cleanup()
     # mpz_ptr _fmpz_promote(fmpz_t f)
-    # mpz_ptr _fmpz_promote_val(fmpz_t f)
+    mpz_ptr _fmpz_promote_val(fmpz_t f)
     void _fmpz_demote(fmpz_t f)
     void _fmpz_demote_val(fmpz_t f)
     int _fmpz_is_canonical(const fmpz_t f)
@@ -84,7 +89,7 @@ cdef extern from "flint/fmpz.h":
     # int fmpz_fprint(FILE * fs, const fmpz_t x)
     int fmpz_print(const fmpz_t x)
     # size_t fmpz_out_raw(FILE * fout, const fmpz_t x )
-    # size_t fmpz_sizeinbase(const fmpz_t f, int b)
+    size_t fmpz_sizeinbase(const fmpz_t f, int b)
     flint_bitcnt_t fmpz_bits(const fmpz_t f)
     slong fmpz_size(const fmpz_t f)
     int fmpz_sgn(const fmpz_t f)

--- a/src/flint/flintlib/types/flint.pxd
+++ b/src/flint/flintlib/types/flint.pxd
@@ -2,8 +2,38 @@
 #
 # Define fundamental types and constants
 
+from libc.stdint cimport int8_t, uint8_t, int64_t
+
 cdef extern from "Python.h":
     ctypedef void PyObject
+
+    ctypedef unsigned long long Py_uintptr_t
+
+    cdef struct PyLongLayout:
+        uint8_t bits_per_digit
+        uint8_t digit_size
+        int8_t digits_order
+        int8_t digit_endianness
+
+    const PyLongLayout * PyLong_GetNativeLayout()
+
+    cdef struct PyLongExport:
+        int64_t value
+        uint8_t negative
+        Py_ssize_t ndigits
+        const void *digits
+        Py_uintptr_t _reserved
+
+    int PyLong_Export(object, PyLongExport *)
+    void PyLong_FreeExport(PyLongExport *)
+
+    ctypedef struct PyLongWriter:
+        pass
+
+    PyLongWriter * PyLongWriter_Create(int negative, Py_ssize_t ndigits, void **digits)
+    object PyLongWriter_Finish(PyLongWriter *writer)
+    void PyLongWriter_Discard(PyLongWriter *writer)
+
 
 cdef enum:
     FMPZ_UNKNOWN = 0
@@ -29,6 +59,11 @@ cdef extern from "gmp.h":
     ctypedef mp_limb_t* mp_ptr
     ctypedef mp_limb_t* mp_srcptr
     ctypedef unsigned long mp_bitcnt_t
+
+    ctypedef struct __mpz_struct:
+        pass
+    ctypedef __mpz_struct mpz_t[1]
+    ctypedef __mpz_struct * mpz_ptr
 
 cdef extern from "flint/fmpz.h":
     ctypedef long slong

--- a/src/flint/types/fmpz.pxd
+++ b/src/flint/types/fmpz.pxd
@@ -1,22 +1,45 @@
 from cpython.long cimport PyLong_Check
 from flint.flint_base.flint_base cimport flint_scalar
-from flint.utils.conversion cimport chars_from_str
-from flint.flintlib.types.flint cimport slong, pylong_as_slong
-from flint.flintlib.types.flint cimport PyObject
-from flint.flintlib.functions.fmpz cimport fmpz_t, fmpz_set_str, fmpz_set_si
+from flint.flintlib.types.flint cimport PyObject, PyLongLayout, PyLong_GetNativeLayout, PyLongExport, PyLong_Export, PyLong_FreeExport
+from flint.flintlib.functions.fmpz cimport fmpz_t, fmpz_set_str, fmpz_set_si, _fmpz_promote_val, _fmpz_demote_val, mpz_import, fmpz_neg, fmpz_ui_pow_ui, fmpz_init, fmpz_sub, fmpz_clear
+
+cdef extern from "<limits.h>":
+    const long LONG_MAX
+    const long LONG_MIN
 
 cdef int fmpz_set_any_ref(fmpz_t x, obj)
 cdef fmpz_get_intlong(fmpz_t x)
 
 cdef inline int fmpz_set_pylong(fmpz_t x, obj):
-    cdef int overflow
-    cdef slong longval
-    longval = pylong_as_slong(<PyObject*>obj, &overflow)
-    if overflow:
-        s = "%x" % obj
-        fmpz_set_str(x, chars_from_str(s), 16)
+    cdef const PyLongLayout * layout
+    cdef PyLongExport long_export
+    cdef fmpz_t tmp
+
+    layout = PyLong_GetNativeLayout()
+
+    PyLong_Export(obj, &long_export)
+    if long_export.digits:
+        z = _fmpz_promote_val(x)
+        mpz_import(z, long_export.ndigits, layout[0].digits_order,
+                   layout[0].digit_size, layout[0].digit_endianness,
+                   layout[0].digit_size*8 - layout[0].bits_per_digit,
+                   long_export.digits)
+        _fmpz_demote_val(x)
+        if long_export.negative:
+            fmpz_neg(x, x)
+        PyLong_FreeExport(&long_export)
     else:
-        fmpz_set_si(x, longval)
+        if LONG_MIN <= long_export.value <= LONG_MAX:
+            fmpz_set_si(x, long_export.value)
+        else:
+            z = _fmpz_promote_val(x)
+            mpz_import(z, 1, -1, 8, 0, 0, &long_export.value);
+            _fmpz_demote_val(x)
+            if long_export.value < 0:
+                fmpz_init(tmp)
+                fmpz_ui_pow_ui(tmp, 2, 64)
+                fmpz_sub(x, x, tmp)
+                fmpz_clear(tmp)
 
 cdef inline int fmpz_set_python(fmpz_t x, obj):
     if PyLong_Check(obj):


### PR DESCRIPTION
Closes #159

This lacks implementation for Python < 3.14.  Not sure how to do this better, conditional compilation seems to be deprecated by Cython.

To my surprise, #324 approach seems to be better.  Here my benchmarks.

Export
------

| Benchmark      | ref     | pr324                 | patch                 |
|----------------|:-------:|:---------------------:|:---------------------:|
| 1<<7           | 166 ns  | 169 ns: 1.02x slower  | 169 ns: 1.02x slower  |
| 1<<38          | 216 ns  | not significant       | 219 ns: 1.01x slower  |
| 1<<300         | 3.06 us | 923 ns: 3.31x faster  | 787 ns: 3.88x faster  |
| 1<<3000        | 15.9 us | 2.17 us: 7.34x faster | 3.70 us: 4.29x faster |
| 1<<10000       | 49.4 us | 5.93 us: 8.33x faster | 11.6 us: 4.27x faster |
| Geometric mean | (ref)   | 2.88x faster          | 2.33x faster          |

Import
--------

| Benchmark      | ref     | pr324                  | patch                 |
|----------------|:-------:|:----------------------:|:---------------------:|
| 1<<7           | 454 ns  | 451 ns: 1.01x faster   | 459 ns: 1.01x slower  |
| 1<<38          | 471 ns  | 466 ns: 1.01x faster   | 475 ns: 1.01x slower  |
| 1<<300         | 4.80 us | 1.91 us: 2.52x faster  | 1.10 us: 4.37x faster |
| 1<<3000        | 23.6 us | 3.07 us: 7.68x faster  | 4.17 us: 5.65x faster |
| 1<<10000       | 73.0 us | 6.78 us: 10.76x faster | 12.5 us: 5.86x faster |
| Geometric mean | (ref)   | 2.92x faster           | 2.69x faster          |

<details>

```py
# bench-export.py

import os

import pyperf

_T = os.getenv('_T')
if _T == "gmpy2.mpz":
    from gmpy2 import mpz
elif _T == "gmp.mpz":
    from gmp import mpz
else:
    from flint import fmpz as mpz

cases = ['1<<7', '1<<38', '1<<300', '1<<3000', '1<<10000']
runner = pyperf.Runner()
for c in cases:
    i = eval(c)
    m = mpz(i)
    runner.bench_func(c, int, m)
```

```py
# bench-import.py

import os

import pyperf

_T = os.getenv('_T')
if _T == "gmpy2.mpz":
    from gmpy2 import mpz
elif _T == "gmp.mpz":
    from gmp import mpz
else:
    from flint import fmpz as mpz

cases = ['1<<7', '1<<38', '1<<300', '1<<3000', '1<<10000']
runner = pyperf.Runner()
for c in cases:
    i = eval(c)
    runner.bench_func(c, mpz, i)
```

</details>