### PR TITLE
Use msys2 UCRT build for Window DLLs

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: msys2/setup-msys2@v2.30.0
         with:
-          msystem: mingw64
+          msystem: ucrt64
         if: ${{ startsWith( matrix.os , 'windows' ) }}
 
         # Install pkgconfig on Windows from choco rather than from msys and

--- a/bin/cibw_before_all_windows.sh
+++ b/bin/cibw_before_all_windows.sh
@@ -3,8 +3,8 @@
 set -o errexit
 
 pacman -S --noconfirm \
-    mingw-w64-x86_64-gcc\
-    mingw-w64-x86_64-tools-git\
+    mingw-w64-ucrt-x86_64-gcc\
+    mingw-w64-ucrt-x86_64-tools-git\
     m4\
     make\
     base-devel\


### PR DESCRIPTION
Use msys2 UCRT build for Window DLLs rather than using the old msvcrt.dll.

I previously tried this in gh-41 but lots of things have changed so maybe it will just work now. I am hoping that this would make it possible to build the extension modules with MSVC but first we change the C runtime and check if that is working. Once we have extension modules building with MSVC that will hopefully make it easier to build wheels for Windows on ARM (gh-360).