### PR TITLE
Pyodide follow-ups

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -211,7 +211,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
 
       - run: pip install pyodide-build
       - run: pyodide xbuildenv install "$PYODIDE_VERSION"

--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -105,15 +105,6 @@ jobs:
           $pkgConfigPath = $pkgConfigPath.Replace('\', '/')
           echo "PKG_CONFIG_PATH=$pkgConfigPath" >> $env:GITHUB_ENV
 
-        # ------------- pyodide ------------- #
-
-      - if: ${{ matrix.kind == 'pyodide' }}
-        name: Set up Emscripten toolchain
-        uses: pyodide/setup-emsdk@ca2dd8aef8c2a0e11743c5c36f0b430ddb694b5c # v15
-        with:
-          version: ${{ env.PYODIDE_EMSCRIPTEN_VERSION }}
-          actions-cache-folder: emsdk-cache
-
         # ------------- actual build ------------- #
 
       - name: Build wheels


### PR DESCRIPTION
xref #394, #401. I bumped to Node.js v24, as that's what we recommend in https://pyodide-build.readthedocs.io/en/latest/tutorials/installation.html#requirements. python-flint doesn't necessarily require it, but v24 is the first to support JSPI.

I have also removed the manual Emscripten toolchain setup, so that we always use the one that cibuildwheel installs via `pyodide xbuildenv install-emscripten` and we have the correct toolchain on PATH. Let's see if that works.